### PR TITLE
Fix quick menu search case sensitivity

### DIFF
--- a/src/components/quick-menu/QuickMenuSection.ts
+++ b/src/components/quick-menu/QuickMenuSection.ts
@@ -52,16 +52,17 @@ export class QuickMenuSection extends BaseUIComponent {
         this.restore();
 
         if (text !== "") {
-            this.menuItems.forEach(menuItem => {
+            const loweredText = text.toLowerCase();
 
-                if (!(menuItem.filterValue.toLocaleLowerCase().includes(text))) {
+            this.menuItems.forEach(menuItem => {
+                if (!menuItem.filterValue.toLocaleLowerCase().includes(loweredText)) {
                     menuItem.hide();
                 }
             });
 
-            let atLeadOneItem = this.menuItems.any(item => item.filterValue.toLocaleLowerCase().includes(text));
+            const atLeastOneItem = this.menuItems.any(item => item.filterValue.toLocaleLowerCase().includes(loweredText));
 
-            if (!atLeadOneItem) {
+            if (!atLeastOneItem) {
                 this.hide();
             }
         }


### PR DESCRIPTION
## Summary
- handle lowercase search in QuickMenuSection

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c9e904e08332b1cfcb032314897a