### PR TITLE
Fix paste command naming

### DIFF
--- a/src/commands/CommandDispatcher.ts
+++ b/src/commands/CommandDispatcher.ts
@@ -92,7 +92,7 @@ export class CommandDispatcher {
                 this.textOperationsService.execCut();
                 break;
 
-            case Commands.past:
+            case Commands.paste:
                 this.textOperationsService.execReplace();
                 break;
 

--- a/src/commands/Commands.ts
+++ b/src/commands/Commands.ts
@@ -13,7 +13,7 @@ export enum Commands {
     removeFormat = "removeFormat",
     copySelected = "copySelected",
     cutSelected = "cutSelected",
-    past = "past",
+    paste = "paste",
 
     /** Block operations commands */
     transformBlock = "transformBlock",

--- a/src/components/floating-toolbar/text-context/Builder.ts
+++ b/src/components/floating-toolbar/text-context/Builder.ts
@@ -196,7 +196,7 @@ export class Builder {
 
         moreOptionsList.append(new DropdownMenuListItem("copyOption", moreOptionsList, Commands.copySelected, null, SVGIcons.copy.htmlElement, "Copy", "Ctrl+C"));
         //moreOptionsList.append(new DropdownMenuListItem("cutOption", moreOptionsList, Commands.cutSelected, null, SVGIcons.cut.htmlElement, "Cut", "Ctrl+X"));
-        //moreOptionsList.append(new DropdownMenuListItem("pasteOption", moreOptionsList, Commands.past, null, SVGIcons.paste.htmlElement, "Replace", "Ctrl+V"));
+        //moreOptionsList.append(new DropdownMenuListItem("pasteOption", moreOptionsList, Commands.paste, null, SVGIcons.paste.htmlElement, "Replace", "Ctrl+V"));
         moreOptionsList.append(new DropdownMenuListItem("duplicateOption", moreOptionsList, Commands.duplicateBlock, null, SVGIcons.duplicate.htmlElement, "Clone", "Ctrl+D"));
         moreOptionsList.append(new DropdownMenuListItem("resetOption", moreOptionsList, Commands.removeFormat, null, SVGIcons.eraser.htmlElement, "Reset Style", "Ctrl+\\"));
 

--- a/src/services/block-operations/BlockOperationsService.ts
+++ b/src/services/block-operations/BlockOperationsService.ts
@@ -115,7 +115,7 @@ export class BlockOperationsService implements IBlockOperationsService {
             return false;
         }
 
-        if (command == Commands.past) {
+        if (command == Commands.paste) {
             if (navigator.clipboard && navigator.clipboard.readText) {
                 navigator.clipboard.readText().then((pastedText: string) => {
                     const selection = document.getSelection();


### PR DESCRIPTION
## Summary
- rename `past` enum value to `paste`
- replace usages of `Commands.past` with `Commands.paste`

## Testing
- `npm test` *(fails: Dependency IFocusStack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cd4231f8833281016142b0a5bc4f