### PR TITLE
Fix block without inner element

### DIFF
--- a/src/services/block-operations/BlockOperationsService.test.ts
+++ b/src/services/block-operations/BlockOperationsService.test.ts
@@ -282,4 +282,21 @@ describe('BlockOperationsService.createNewElementAndSplitContent', () => {
         });
     });
 
+    describe('deleteTheCurrentElementAndTheDraggableBlockIfEmpty', () => {
+        test('should remove block when last content element is deleted', () => {
+            const block = document.createElement('div');
+            block.className = 'block deletable';
+
+            const content = document.createElement('p');
+            content.className = 'johannes-content-element editable';
+
+            block.appendChild(content);
+            document.body.appendChild(block);
+
+            service.deleteTheCurrentElementAndTheDraggableBlockIfEmpty(content);
+
+            expect(document.body.contains(block)).toBe(false);
+        });
+    });
+
 });

--- a/src/services/block-operations/BlockOperationsService.ts
+++ b/src/services/block-operations/BlockOperationsService.ts
@@ -1025,7 +1025,9 @@ export class BlockOperationsService implements IBlockOperationsService {
 
         actual?.remove();
 
-        if (parentBlock && parentBlock.querySelectorAll('.editable').length == 0) {
+        if (parentBlock &&
+            parentBlock.querySelectorAll('.editable').length === 0 &&
+            !parentBlock.querySelector('.johannes-content-element')) {
             parentBlock.remove();
         }
     }


### PR DESCRIPTION
## Summary
- avoid leftover blocks without content elements
- test block removal when internal element is deleted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e1a42190833283575c0ba8e7fa58