### PR TITLE
fix placeholder rendering when clearing text

### DIFF
--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -371,22 +371,24 @@ export class Content extends BaseUIComponent {
 
     reRenderPlaceholder() {
         document.addEventListener(DefaultJSEvents.Input, function (event: Event) {
-            if (event.target instanceof HTMLElement) {
-                const editableElement = event.target;
+            if (!(event.target instanceof HTMLElement)) {
+                return;
+            }
 
-                if (!Utils.isEventFromContentWrapper(event)) {
-                    return;
-                }
+            const editableElement = event.target;
 
-                if (editableElement.isContentEditable) {
-                    if (editableElement.hasAttribute('data-placeholder')) {
-                        const customPlaceholder = editableElement.getAttribute('data-placeholder');
+            if (!Utils.isEventFromContentWrapper(event)) {
+                return;
+            }
 
-                        if (editableElement.textContent?.trim() === '') {
-                            editableElement.setAttribute('data-placeholder', customPlaceholder || '');
-                            editableElement.textContent = '';
-                        }
-                    }
+            if (editableElement.isContentEditable && editableElement.hasAttribute('data-placeholder')) {
+                const customPlaceholder = editableElement.getAttribute('data-placeholder') || '';
+
+                DOMUtils.trimEmptyTextAndBrElements(editableElement);
+
+                if (editableElement.textContent?.trim() === '') {
+                    editableElement.setAttribute('data-placeholder', customPlaceholder);
+                    editableElement.textContent = '';
                 }
             }
         });


### PR DESCRIPTION
## Summary
- ensure editable placeholders reappear once content is removed
- trim empty `<br>` elements on input events so placeholder state is detected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ea905cf08332b57c98a6b660b868