### PR TITLE
Remove Portuguese comments

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -807,7 +807,6 @@ mark {
 }
 
 
-/* Para telas com densidade média */
 /* @media only screen and (-webkit-min-device-pixel-ratio: 2),
 only screen and (min--moz-device-pixel-ratio: 2),
 only screen and (min-resolution: 192dpi),

--- a/src/core/EmbedTool.ts
+++ b/src/core/EmbedTool.ts
@@ -165,7 +165,6 @@ export class EmbedTool {
         placeholder.style.fontWeight = "bold";
         placeholder.style.borderRadius = "8px";
     
-        // Evento: usuário clicou → criar o iframe dinamicamente
         placeholder.addEventListener("click", () => {
             const iframe = document.createElement('iframe');
             iframe.classList.add("spotify-embed");


### PR DESCRIPTION
## Summary
- remove Portuguese comments in CSS and TypeScript

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840f046f3688332870232d735ad9035