### PR TITLE
Fix leftover blocks in Firefox

### DIFF
--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -13,6 +13,7 @@ import { TableUtils } from "@/utilities/TableUtils";
 import { DefaultJSEvents } from "@/common/DefaultJSEvents";
 import { KeyboardKeys } from "@/common/KeyboardKeys";
 import { Utils } from "@/utilities/Utils";
+import { BlockOperationsService } from "@/services/block-operations/BlockOperationsService";
 
 export class Content extends BaseUIComponent {
 
@@ -99,6 +100,7 @@ export class Content extends BaseUIComponent {
 
         this.clearSelectionOnDrag();
         this.reRenderPlaceholder();
+        this.observeEmptyBlocks();
 
         document.addEventListener('click', (event) => {
             const target = event.target as HTMLInputElement;
@@ -390,6 +392,16 @@ export class Content extends BaseUIComponent {
                 }
             }
         });
+    }
+
+    observeEmptyBlocks() {
+        const wrapper = document.querySelector('#johannesEditor .content-wrapper');
+        if (!wrapper) return;
+        const service = BlockOperationsService.getInstance();
+        const observer = new MutationObserver(() => {
+            service.removeEmptyBlocks();
+        });
+        observer.observe(wrapper, { childList: true, subtree: true });
     }
 
     static getInstance(): Content {

--- a/src/services/block-operations/BlockOperationsService.test.ts
+++ b/src/services/block-operations/BlockOperationsService.test.ts
@@ -282,4 +282,70 @@ describe('BlockOperationsService.createNewElementAndSplitContent', () => {
         });
     });
 
+    describe('deleteTheCurrentElementAndTheDraggableBlockIfEmpty', () => {
+        test('should remove block when last content element is deleted', () => {
+            const block = document.createElement('div');
+            block.className = 'block deletable';
+
+            const content = document.createElement('p');
+            content.className = 'johannes-content-element editable';
+
+            block.appendChild(content);
+            document.body.appendChild(block);
+
+            service.deleteTheCurrentElementAndTheDraggableBlockIfEmpty(content);
+
+            expect(document.body.contains(block)).toBe(false);
+        });
+
+        test('should remove empty list items inside block', () => {
+            const block = document.createElement('div');
+            block.className = 'block deletable';
+
+            const listElement = document.createElement('ul');
+            listElement.className = 'johannes-content-element list';
+
+            const createItem = (text: string) => {
+                const li = document.createElement('li');
+                li.className = 'deletable list-item';
+                const input = document.createElement('input');
+                const div = document.createElement('div');
+                div.className = 'focusable editable';
+                div.textContent = text;
+                li.appendChild(input);
+                li.appendChild(div);
+                return li;
+            };
+
+            const li1 = createItem('one');
+            const li2 = createItem('two');
+            const li3 = createItem('three');
+
+            listElement.appendChild(li1);
+            listElement.appendChild(li2);
+            listElement.appendChild(li3);
+            block.appendChild(listElement);
+            document.body.appendChild(block);
+
+            li2.innerHTML = '<br>'; // simulate leftover empty item
+
+            service.deleteTheCurrentElementAndTheDraggableBlockIfEmpty(listElement);
+
+            expect(listElement.querySelectorAll('li').length).toBe(2);
+            expect(listElement.contains(li2)).toBe(false);
+        });
+    });
+
+    describe('removeEmptyBlocks', () => {
+        test('should remove blocks without content elements', () => {
+            const block = document.createElement('div');
+            block.className = 'block deletable';
+            document.body.appendChild(block);
+
+            service.removeEmptyBlocks();
+
+            expect(document.body.contains(block)).toBe(false);
+        });
+    });
+
 });

--- a/src/services/block-operations/BlockOperationsService.ts
+++ b/src/services/block-operations/BlockOperationsService.ts
@@ -1018,6 +1018,30 @@ export class BlockOperationsService implements IBlockOperationsService {
         return focusedElement;
     }
 
+    cleanupEmptyListItems(block: Element) {
+        const listItems = block.querySelectorAll('li');
+        listItems.forEach(item => {
+            DOMUtils.trimEmptyTextAndBrElements(item);
+            const hasContent = item.querySelector('.focusable, input, .editable');
+            if (!hasContent && !DOMUtils.hasTextContent(item)) {
+                item.remove();
+            }
+        });
+    }
+
+    removeEmptyBlocks() {
+        const blocks = document.querySelectorAll('.block.deletable');
+        blocks.forEach(block => {
+            this.cleanupEmptyListItems(block);
+            if (
+                block.querySelectorAll('.editable').length === 0 &&
+                !block.querySelector('.johannes-content-element')
+            ) {
+                block.remove();
+            }
+        });
+    }
+
     deleteTheCurrentElementAndTheDraggableBlockIfEmpty(currentElement: Element) {
 
         const parentBlock = currentElement.closest('.block');
@@ -1025,7 +1049,13 @@ export class BlockOperationsService implements IBlockOperationsService {
 
         actual?.remove();
 
-        if (parentBlock && parentBlock.querySelectorAll('.editable').length == 0) {
+        if (parentBlock) {
+            this.cleanupEmptyListItems(parentBlock);
+        }
+
+        if (parentBlock &&
+            parentBlock.querySelectorAll('.editable').length === 0 &&
+            !parentBlock.querySelector('.johannes-content-element')) {
             parentBlock.remove();
         }
     }


### PR DESCRIPTION
## Summary
- monitor DOM mutations to clean up empty blocks automatically
- expose `cleanupEmptyListItems` and add `removeEmptyBlocks`
- test block removal via `removeEmptyBlocks`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840e1a42190833283575c0ba8e7fa58