### PR TITLE
Fix paste splitting on title element

### DIFF
--- a/src/components/editor/Editor.ts
+++ b/src/components/editor/Editor.ts
@@ -206,9 +206,9 @@ export class Editor extends BaseUIComponent {
     
         if (textHtml !== "") {
             const currentBlock = DOMUtils.getContentTypeFromActiveElement();
-            const isParagraph = currentBlock === 'p';
-    
-            if (isParagraph) {
+            const isParagraphOrTitle = currentBlock === 'p' || target?.tagName.toLowerCase() === 'h1';
+
+            if (isParagraphOrTitle) {
                 const blocks = Editor.extractClipboardContent(textHtml);
     
                 if (blocks.length > 0) {


### PR DESCRIPTION
## Summary
- treat title as a block when parsing pasted HTML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841edfac6e48332b7291dd0ed7a6328