### PR TITLE
Fix list item cleanup

### DIFF
--- a/src/core/Memento.ts
+++ b/src/core/Memento.ts
@@ -99,6 +99,7 @@ export class Memento implements IMemento {
         }
 
         this.debouncedSaveState();
+        DOMUtils.removeEmptyListItems();
       }
     });
   }

--- a/src/utilities/DOMUtils.test.ts
+++ b/src/utilities/DOMUtils.test.ts
@@ -1459,3 +1459,42 @@ describe("DOMUtils.getCurrentActiveBlock", () => {
         expect(block).toBeNull();
     });
 });
+
+describe("DOMUtils.removeEmptyListItems", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    test("should remove list items without text", () => {
+        const ul = document.createElement("ul");
+        const li1 = document.createElement("li");
+        li1.textContent = "Item";
+        const li2 = document.createElement("li");
+        li2.innerHTML = "<br>";
+
+        ul.appendChild(li1);
+        ul.appendChild(li2);
+        document.body.appendChild(ul);
+
+        DOMUtils.removeEmptyListItems(document.body);
+
+        expect(ul.querySelectorAll("li").length).toBe(1);
+        expect(ul.querySelector("li")?.textContent).toBe("Item");
+    });
+
+    test("should remove list items with empty focusable element", () => {
+        const ul = document.createElement("ul");
+        const li = document.createElement("li");
+        const div = document.createElement("div");
+        div.classList.add("focusable");
+        div.contentEditable = "true";
+        div.innerHTML = "<br>";
+        li.appendChild(div);
+        ul.appendChild(li);
+        document.body.appendChild(ul);
+
+        DOMUtils.removeEmptyListItems(document.body);
+
+        expect(ul.querySelectorAll("li").length).toBe(0);
+    });
+});

--- a/src/utilities/DOMUtils.ts
+++ b/src/utilities/DOMUtils.ts
@@ -1022,4 +1022,15 @@ export class DOMUtils {
 
         return postRange.toString().trim() === '';
     }
+
+    static removeEmptyListItems(parent: ParentNode = document): void {
+        const listItems = parent.querySelectorAll('li');
+
+        listItems.forEach(li => {
+            DOMUtils.trimEmptyTextAndBrElements(li);
+            if (!DOMUtils.hasTextContent(li)) {
+                li.remove();
+            }
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- handle empty `<li>` elements by trimming them out
- ensure cleanup runs on keyup events
- test list item cleanup helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841eccc266883329624e0b4d42d3de4