### PR TITLE
Fix figcaption paste handling

### DIFF
--- a/src/components/editor/Editor.test.ts
+++ b/src/components/editor/Editor.test.ts
@@ -204,4 +204,25 @@ describe('Editor.handlePasteEvent', () => {
 
         expect(insertTextAtCursor).toHaveBeenCalledWith('Fallback text');
     });
+
+    test('should insert plain text when pasting into figcaption', () => {
+        const clipboardData = {
+            getData: (type: string) => {
+                if (type === 'text/html') return '<strong>bold</strong>';
+                if (type === 'text/plain') return 'bold';
+                return '';
+            }
+        };
+
+        clipboardEvent = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+        Object.defineProperty(clipboardEvent, 'clipboardData', { value: clipboardData });
+
+        const target = document.createElement('figcaption');
+        target.setAttribute('contenteditable', 'true');
+        Object.defineProperty(clipboardEvent, 'target', { value: target });
+
+        Editor.handlePasteEvent(clipboardEvent, blockOperationsService);
+
+        expect(insertTextAtCursor).toHaveBeenCalledWith('bold');
+    });
 });

--- a/src/components/editor/Editor.ts
+++ b/src/components/editor/Editor.ts
@@ -200,6 +200,14 @@ export class Editor extends BaseUIComponent {
     
         const clipboardData = event.clipboardData;
         if (!clipboardData) return;
+
+        if (target && target.tagName === 'FIGCAPTION') {
+            const plainText = clipboardData.getData('text/plain');
+            if (plainText) {
+                Editor.insertTextAtCursor(plainText);
+            }
+            return;
+        }
     
         const text = clipboardData.getData('text/plain');
         const textHtml = clipboardData.getData('text/html');


### PR DESCRIPTION
## Summary
- enforce plain text pasting when the target element is a `figcaption`
- add tests for figcaption paste behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f17149c883329d48e886e1ae7ee4