### PR TITLE
Add math formula block type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,12 @@
     "": {
       "name": "johannes",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "fix": "^0.0.3",
         "highlight.js": "^11.10.0",
+        "katex": "^0.16.22",
         "micromatch": "^4.0.8",
         "postcss": "^8.4.39",
         "rangy": "^1.3.1"
@@ -19,6 +20,7 @@
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",
         "@types/jest": "^29.5.12",
+        "@types/katex": "^0.16.7",
         "copy-webpack-plugin": "^12.0.2",
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",
@@ -1517,6 +1519,13 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -5928,6 +5937,31 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.22",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
+      "integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/kind-of": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "webpack": "^5.95.0",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.4"
+    "webpack-dev-server": "^5.0.4",
+    "@types/katex": "^0.16.7"
   },
   "dependencies": {
     "braces": "^3.0.3",
@@ -45,6 +46,7 @@
     "highlight.js": "^11.10.0",
     "micromatch": "^4.0.8",
     "postcss": "^8.4.39",
-    "rangy": "^1.3.1"
+    "rangy": "^1.3.1",
+    "katex": "^0.16.22"
   }
 }

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1411,6 +1411,19 @@ pre code {
 
 }
 
+.math-block {
+    display: flex;
+    flex-direction: column;
+}
+
+.math-input {
+    min-height: 1.2em;
+}
+
+.math-render {
+    margin-top: 0.5rem;
+}
+
 
 
 @keyframes shake {

--- a/src/common/ContentTypes.ts
+++ b/src/common/ContentTypes.ts
@@ -13,5 +13,6 @@ export enum ContentTypes {
     Table = "table",
     Image = "image",
     Script = "script",
+    Math = "math",
     Iframe = "iframe"
 }

--- a/src/components/floating-toolbar/text-context/Builder.ts
+++ b/src/components/floating-toolbar/text-context/Builder.ts
@@ -68,6 +68,7 @@ export class Builder {
         turnIntoBarList.append(new DropdownMenuListItem("turnIntoOptionBulletedList", turnIntoBarList, Commands.transformBlock, ElementFactoryService.ELEMENT_TYPES.BULLETED_LIST, SVGIcons.b_list.htmlElement, "Bulleted list", "Ctrl+."));
         turnIntoBarList.append(new DropdownMenuListItem("turnIntoOptionNumberedList", turnIntoBarList, Commands.transformBlock, ElementFactoryService.ELEMENT_TYPES.NUMBERED_LIST, SVGIcons.n_list.htmlElement, "Numbered list", "Ctrl+/"));
         turnIntoBarList.append(new DropdownMenuListItem("turnIntoOptionBlockCode", turnIntoBarList, Commands.transformBlock, ElementFactoryService.ELEMENT_TYPES.CODE, SVGIcons.code.htmlElement, "Block code"));
+        turnIntoBarList.append(new DropdownMenuListItem("turnIntoOptionFormula", turnIntoBarList, Commands.transformBlock, ElementFactoryService.ELEMENT_TYPES.MATH, SVGIcons.formula.htmlElement, "Formula"));
         turnIntoBarList.append(new DropdownMenuListItem("turnIntoOptionQuote", turnIntoBarList, Commands.transformBlock, ElementFactoryService.ELEMENT_TYPES.QUOTE, SVGIcons.quote.htmlElement, "Quote"));
         //turnIntoBarList.append(new DropdownMenuListItem("turnIntoOptionHeading1", turnIntoBarList, Commands.transformBlock, ElementFactoryService.ELEMENT_TYPES.HEADER_1, SVGIcons.head1.htmlElement, "Heading 1", "Ctrl+Alt+1"));
         turnIntoBarList.append(new DropdownMenuListItem("turnIntoOptionHeading2", turnIntoBarList, Commands.transformBlock, ElementFactoryService.ELEMENT_TYPES.HEADER_2, SVGIcons.head2.htmlElement, "Heading 2", "Ctrl+Alt+2"));
@@ -216,6 +217,7 @@ const SVGIcons: any = {
     b_list: new SVGIcon("icon-wordpress-bulleted-list", Sizes.large),
     n_list: new SVGIcon("icon-wordpress-numbered-list", Sizes.large),
     code: new SVGIcon("icon-wordpress-code-mark", Sizes.large),
+    formula: new SVGIcon("icon-wordpress-equation-mark", Sizes.large),
     quote: new SVGIcon("icon-wordpress-quote", Sizes.large),
     head1: new SVGIcon("icon-julia-head-1", Sizes.large),
     head2: new SVGIcon("icon-julia-head-2", Sizes.large),

--- a/src/components/quick-menu/QuickMenuBuilder.ts
+++ b/src/components/quick-menu/QuickMenuBuilder.ts
@@ -19,6 +19,7 @@ export class QuickMenuBuilder {
             //new QuickMenuItem(basicBlocksSection, 'Table', 'Organize data in rows and columns.', 'icon-material-table', ElementFactoryService.ELEMENT_TYPES.TABLE, "table tr th"),
             new QuickMenuItem(basicBlocksSection, 'Callout', 'Emphasize key points with a callout box.', Icons.Callout, ElementFactoryService.ELEMENT_TYPES.CALLOUT, "callout note spotlight"),
             new QuickMenuItem(basicBlocksSection, 'Code', 'Include a code snippet.', 'icon-wordpress-code-mark', ElementFactoryService.ELEMENT_TYPES.CODE, "code script source markup"),
+            new QuickMenuItem(basicBlocksSection, 'Formula', 'Display a math expression.', 'icon-wordpress-equation-mark', ElementFactoryService.ELEMENT_TYPES.MATH, "formula math latex equation"),
             new QuickMenuItem(basicBlocksSection, 'Quote', 'Highlight text as a quote.', 'icon-wordpress-quote', ElementFactoryService.ELEMENT_TYPES.QUOTE, "quote blockquote citation quotation cite"),
             new QuickMenuItem(basicBlocksSection, 'Heading 2', 'Medium header for sections.', 'icon-julia-head-2', ElementFactoryService.ELEMENT_TYPES.HEADER_2, "header 2 heading 2 h2"),
             new QuickMenuItem(basicBlocksSection, 'Heading 3', 'Small header for subsections.', 'icon-julia-head-2', ElementFactoryService.ELEMENT_TYPES.HEADER_3, "header 3 heading 3 h3"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import './assets/css/main.css';
 import 'highlight.js/styles/an-old-hope.css';
+import 'katex/dist/katex.min.css';
 import { UIBuilder } from './builders/UIBuilder';
 import { CommandDispatcher } from './commands/CommandDispatcher';
 import { ShortcutListeners } from './core/ShortcutListeners';

--- a/src/services/block-operations/BlockOperationsService.ts
+++ b/src/services/block-operations/BlockOperationsService.ts
@@ -496,6 +496,16 @@ export class BlockOperationsService implements IBlockOperationsService {
                 break;
             }
 
+            case ElementFactoryService.ELEMENT_TYPES.MATH: {
+                newContentBlock = this.elementFactoryService.create(ElementFactoryService.ELEMENT_TYPES.MATH);
+                const input = newContentBlock.querySelector('.math-input');
+                if (input) {
+                    (input as HTMLElement).textContent = content || '';
+                    (input as HTMLElement).dispatchEvent(new Event('input'));
+                }
+                break;
+            }
+
             case ElementFactoryService.ELEMENT_TYPES.QUOTE: {
                 newContentBlock = this.elementFactoryService.create(ElementFactoryService.ELEMENT_TYPES.QUOTE);
 

--- a/src/services/element-factory/ElementFactoryService.ts
+++ b/src/services/element-factory/ElementFactoryService.ts
@@ -5,6 +5,7 @@ import { Icons } from "@/common/Icons";
 import { ToolboxOptions } from "@/components/block-toolbox/ToolboxOptions";
 import { CommonClasses } from "@/common/CommonClasses";
 import hljs from 'highlight.js';
+import katex from 'katex';
 
 interface ElementCreator {
     (content: string | null): HTMLElement;
@@ -26,6 +27,7 @@ export class ElementFactoryService implements IElementFactoryService {
         BLOCK_HEADER_5: "block-h5",
         BLOCK_HEADER_6: "block-h6",
         BLOCK_CODE: "block-code",
+        BLOCK_MATH: "block-math",
         BLOCK_PRE: "block-pre",
         BLOCK_BLOCKQUOTE: "block-blockquote",
 
@@ -36,6 +38,7 @@ export class ElementFactoryService implements IElementFactoryService {
         CHECKBOX_ITEM: "checkboxItem",
         LIST_ITEM: "listItem",
         CODE: "code",
+        MATH: "math",
         QUOTE: "blockquote",
         BULLETED_LIST: "ul",
         NUMBERED_LIST: "ol",
@@ -75,6 +78,7 @@ export class ElementFactoryService implements IElementFactoryService {
         this.register(ElementFactoryService.ELEMENT_TYPES.BLOCK_HEADER_5, ElementFactoryService.blockHeadingCreator(5));
         this.register(ElementFactoryService.ELEMENT_TYPES.BLOCK_HEADER_6, ElementFactoryService.blockHeadingCreator(6));
         this.register(ElementFactoryService.ELEMENT_TYPES.BLOCK_CODE, ElementFactoryService.blockCodeCreator());
+        this.register(ElementFactoryService.ELEMENT_TYPES.BLOCK_MATH, ElementFactoryService.blockMathCreator());
         this.register(ElementFactoryService.ELEMENT_TYPES.BLOCK_PRE, ElementFactoryService.blockCodeCreator());
         this.register(ElementFactoryService.ELEMENT_TYPES.BLOCK_BLOCKQUOTE, ElementFactoryService.blockBlockquoteCreator());
         this.register(ElementFactoryService.ELEMENT_TYPES.BLOCK_BULLETED_LIST, ElementFactoryService.blockUlCreator());
@@ -83,6 +87,7 @@ export class ElementFactoryService implements IElementFactoryService {
         this.register(ElementFactoryService.ELEMENT_TYPES.CHECKBOX_ITEM, ElementFactoryService.checkboxItemCreator());
         this.register(ElementFactoryService.ELEMENT_TYPES.LIST_ITEM, ElementFactoryService.listItemCreator());
         this.register(ElementFactoryService.ELEMENT_TYPES.CODE, ElementFactoryService.codeCreator());
+        this.register(ElementFactoryService.ELEMENT_TYPES.MATH, ElementFactoryService.mathCreator());
         this.register(ElementFactoryService.ELEMENT_TYPES.QUOTE, ElementFactoryService.quoteCreator());
         this.register(ElementFactoryService.ELEMENT_TYPES.CHECK_LIST, ElementFactoryService.checkListCreator());
         this.register(ElementFactoryService.ELEMENT_TYPES.BULLETED_LIST, ElementFactoryService.bulletedListCreator());
@@ -155,6 +160,13 @@ export class ElementFactoryService implements IElementFactoryService {
 
     }
 
+    private static blockMathCreator(): ElementCreator {
+        return content => {
+            return ElementFactoryService.blockMath(content || "");
+        };
+
+    }
+
     private static blockBlockquoteCreator(): ElementCreator {
         return content => {
             return ElementFactoryService.blockBlockquote(content || "");
@@ -211,6 +223,12 @@ export class ElementFactoryService implements IElementFactoryService {
     private static codeCreator(): ElementCreator {
         return content => {
             return ElementFactoryService.code(content || "");
+        };
+    }
+
+    private static mathCreator(): ElementCreator {
+        return content => {
+            return ElementFactoryService.math(content || "");
         };
     }
 
@@ -440,6 +458,35 @@ export class ElementFactoryService implements IElementFactoryService {
         return container;
     }
 
+    private static math(content: string): HTMLElement {
+        const container = document.createElement('div');
+        container.classList.add("johannes-content-element", "math-block", "swittable", ToolboxOptions.IncludeBlockToolbarClass, ToolboxOptions.ExtraOptionsClass);
+        container.setAttribute('data-content-type', ContentTypes.Math);
+
+        const input = document.createElement('div');
+        input.classList.add('math-input', 'focusable', 'editable');
+        input.contentEditable = 'true';
+        input.setAttribute('data-placeholder', "\\text{Formula}");
+        input.textContent = content || "";
+
+        const render = document.createElement('div');
+        render.classList.add('math-render');
+
+        container.appendChild(input);
+        container.appendChild(render);
+
+        const renderFormula = () => {
+            try {
+                katex.render(input.textContent || '', render, { throwOnError: false });
+            } catch (e) {}
+        };
+
+        input.addEventListener('input', renderFormula);
+        renderFormula();
+
+        return container;
+    }
+
     private static quote(content: string): HTMLElement {
 
         const contentElement = document.createElement("div");
@@ -588,6 +635,18 @@ export class ElementFactoryService implements IElementFactoryService {
     static blockCode(content: string) {
         let newDiv = document.createElement('div');
         let newElement = ElementFactoryService.code(content);
+
+        newDiv.id = `b-${Utils.generateUniqueId()}`;
+        newDiv.appendChild(newElement);
+        newDiv.classList.add('block');
+        newDiv.classList.add('deletable');
+
+        return newDiv;
+    }
+
+    static blockMath(content: string) {
+        let newDiv = document.createElement('div');
+        let newElement = ElementFactoryService.math(content);
 
         newDiv.id = `b-${Utils.generateUniqueId()}`;
         newDiv.appendChild(newElement);


### PR DESCRIPTION
## Summary
- support math formulas using KaTeX
- style new `.math-block` rendering
- expose `math` content type and builder API
- enable formula option in quick menu and toolbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68432f3437288332859d15760a9bd2f9