### PR TITLE
Reposition block toolbar

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1271,8 +1271,10 @@ td::placeholder {
     padding-right: 10px;
     transition: visibility 0.2s;
 
-    top: 5px;
-    right: 5px;
+    /* Position the toolbar outside of the block so it doesn't overlap content */
+    top: -1.75rem;
+    right: 0;
+    z-index: 999999;
     border-radius: 4px;
 }
 


### PR DESCRIPTION
## Summary
- move block toolbar outside the block so content isn't covered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684395d52be88332a672eb04acc59ca8