### PR TITLE
Implement formula placeholder with editable input

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1424,6 +1424,12 @@ pre code {
     margin-top: 0.5rem;
 }
 
+.math-done-button {
+    cursor: pointer;
+    align-self: flex-start;
+    margin-top: 0.5rem;
+}
+
 
 
 @keyframes shake {


### PR DESCRIPTION
## Summary
- add DOMUtils import and build a formula placeholder element
- open math input on block creation and when clicking placeholder
- add Done button to finalize editing
- style math block done button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684476f1493483328cfd3c103eeffeca