### PR TITLE
Implement placeholder for math block

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1424,6 +1424,20 @@ pre code {
     margin-top: 0.5rem;
 }
 
+.math-edit {
+    display: none;
+    gap: 0.5rem;
+    flex-direction: column;
+}
+
+.math-block.editing .math-edit {
+    display: flex;
+}
+
+.math-block.editing .content-placeholder {
+    display: none;
+}
+
 
 
 @keyframes shake {

--- a/src/common/CommonClasses.ts
+++ b/src/common/CommonClasses.ts
@@ -34,5 +34,7 @@ export enum CommonClasses {
     ShowMediaInputUpload =  "show-media-input-upload",
     ShowMediaInputEmbed =  "show-media-input-embed",
 
+    ShowMathInputOnClick = "show-math-input-on-click",
+
     BlockToolbarWrapper = "block-toolbar-wrapper"
 }

--- a/src/common/Icons.ts
+++ b/src/common/Icons.ts
@@ -26,6 +26,7 @@ export enum Icons {
     GitHub = "icon-bootstrap-github",
     GitLab = "icon-bootstrap-gitlab",
     CodePen = "icon-codepen",
+    Formula = "icon-wordpress-equation-mark",
     YouTube = "icon-bootstrap-youtube"
 
 }

--- a/src/services/element-factory/ElementFactoryService.ts
+++ b/src/services/element-factory/ElementFactoryService.ts
@@ -460,19 +460,46 @@ export class ElementFactoryService implements IElementFactoryService {
 
     private static math(content: string): HTMLElement {
         const container = document.createElement('div');
-        container.classList.add("johannes-content-element", "math-block", "swittable", ToolboxOptions.IncludeBlockToolbarClass, ToolboxOptions.ExtraOptionsClass);
+        container.classList.add(
+            "johannes-content-element",
+            "math-block",
+            "swittable",
+            ToolboxOptions.IncludeBlockToolbarClass,
+            ToolboxOptions.ExtraOptionsClass
+        );
         container.setAttribute('data-content-type', ContentTypes.Math);
+
+        const placeholder = document.createElement('div');
+        placeholder.classList.add('content-placeholder', CommonClasses.ShowMathInputOnClick);
+
+        const icon = this.createIcon(Icons.Formula);
+        const placeholderText = document.createElement('span');
+        placeholderText.innerText = 'Write a formula';
+
+        placeholder.appendChild(icon);
+        placeholder.appendChild(placeholderText);
+
+        const editWrapper = document.createElement('div');
+        editWrapper.classList.add('math-edit', CommonClasses.EditorOnly);
 
         const input = document.createElement('div');
         input.classList.add('math-input', 'focusable', 'editable');
         input.contentEditable = 'true';
         input.setAttribute('data-placeholder', "\\text{Formula}");
-        input.textContent = content || "";
+        input.textContent = content || '';
+
+        const done = document.createElement('button');
+        done.classList.add('blue-button');
+        done.textContent = 'Done';
+
+        editWrapper.appendChild(input);
+        editWrapper.appendChild(done);
 
         const render = document.createElement('div');
         render.classList.add('math-render');
 
-        container.appendChild(input);
+        container.appendChild(placeholder);
+        container.appendChild(editWrapper);
         container.appendChild(render);
 
         const renderFormula = () => {
@@ -481,8 +508,32 @@ export class ElementFactoryService implements IElementFactoryService {
             } catch (e) {}
         };
 
+        const showInput = () => {
+            container.classList.add('editing');
+            setTimeout(() => input.focus(), 0);
+        };
+
+        const hideInput = () => {
+            container.classList.remove('editing');
+        };
+
+        placeholder.addEventListener('click', showInput);
+        container.addEventListener('click', (e) => {
+            if (e.target === container && !container.classList.contains('editing')) {
+                showInput();
+            }
+        });
+        done.addEventListener('click', (e) => {
+            e.preventDefault();
+            hideInput();
+        });
+
         input.addEventListener('input', renderFormula);
         renderFormula();
+
+        if (!content) {
+            showInput();
+        }
 
         return container;
     }


### PR DESCRIPTION
## Summary
- allow formula blocks to be edited via placeholder
- style editing state for math blocks
- add icon and class constants for math input

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684479aaa5488332bcc8fd4effaba7a5