### PR TITLE
Enable real-time syntax highlight

### DIFF
--- a/src/services/element-factory/ElementFactoryService.ts
+++ b/src/services/element-factory/ElementFactoryService.ts
@@ -445,10 +445,16 @@ export class ElementFactoryService implements IElementFactoryService {
 
         pre.appendChild(code);
 
-        code.addEventListener("blur", () => {
+        const debouncedHighlight = Utils.debounce(() => {
             code.removeAttribute("data-highlighted");
             hljs.highlightElement(code);
+        }, 200);
+
+        code.addEventListener("blur", () => {
+            debouncedHighlight();
         });
+
+        code.addEventListener("input", debouncedHighlight);
 
         codeBlock.appendChild(pre);
         container.appendChild(codeBlock);

--- a/src/utilities/Utils.ts
+++ b/src/utilities/Utils.ts
@@ -15,6 +15,19 @@ export class Utils {
         }).join("");
     }
 
+    static debounce<T extends (...args: any[]) => void>(func: T, wait: number) {
+        let timeout: ReturnType<typeof setTimeout> | null = null;
+        return (...args: Parameters<T>) => {
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+            timeout = setTimeout(() => {
+                timeout = null;
+                func(...args);
+            }, wait);
+        };
+    }
+
     static isEventFromContentWrapper(event: Event): boolean {
         const target = event.target;
         const contentWrapper = document.querySelector('#johannesEditor .content-wrapper');


### PR DESCRIPTION
## Summary
- add general `Utils.debounce` helper
- use the helper in `ElementFactoryService` to highlight code while typing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684485bfa43883328e0e67ed502dc64c