### PR TITLE
Fix Turn Into separator visibility when updating position

### DIFF
--- a/src/components/floating-toolbar/text-context/Toolbar.ts
+++ b/src/components/floating-toolbar/text-context/Toolbar.ts
@@ -319,6 +319,10 @@ export class Toolbar extends FloatingToolbarBase {
             this.initialRect = null;
             return;
         } else if (hasContent && !isSelecting) {
+
+            this.hideTurnInto();
+            this.hideMoreOptions();
+
             if (!this.isVisible) {
 
                 if (!this.canShowFloatingToolbar()) {
@@ -433,9 +437,9 @@ export class Toolbar extends FloatingToolbarBase {
             return;
         };
 
-        this.changeToolbarPositionToBeClosedToSelection();
         this.hideTurnInto();
         this.hideMoreOptions();
+        this.changeToolbarPositionToBeClosedToSelection();
 
     }
 


### PR DESCRIPTION
## Summary
- hide Turn Into dropdown and separator before repositioning the text toolbar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844904628988332bfee33fb43d5d277