### PR TITLE
Add caption control option

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -61,10 +61,12 @@ figure figcaption[data-placeholder]:empty:before {
 }
 
 figure figcaption {
-    max-width: inherit;
-    width: fit-content;
-    display: inline-block;
+    max-width: 100%;
+    width: 100%;
+    display: block;
+    text-align: center;
     color: #84888d;
+    margin-top: 0.25rem;
 }
 
 .block-caption[data-placeholder]:empty:before {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -67,6 +67,17 @@ figure figcaption {
     color: #84888d;
 }
 
+.block-caption[data-placeholder]:empty:before {
+    content: attr(data-placeholder) !important;
+    display: inline-block !important;
+}
+
+.block-caption {
+    width: 100%;
+    text-align: center;
+    color: #84888d;
+}
+
 /** CSS reset */
 .button-reset {
     border: none;

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1279,13 +1279,13 @@ td::placeholder {
 .block-toolbar-wrapper {
     width: 0;
     height: 0;
-    position: relative;
+    position: absolute;
+    top: 0;
+    right: 0;
     overflow: visible;
     margin: 0;
     padding: 0;
-    display: contents;
     display: block;
-
 }
 
 .block-toolbar {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -67,6 +67,7 @@ figure figcaption {
     text-align: center;
     color: #84888d;
     margin-top: 0.25rem;
+    box-sizing: border-box;
 }
 
 .block-caption[data-placeholder]:empty:before {
@@ -78,6 +79,7 @@ figure figcaption {
     width: 100%;
     text-align: center;
     color: #84888d;
+    box-sizing: border-box;
 }
 
 /** CSS reset */
@@ -274,6 +276,7 @@ p.johannes-content-element {
 
 .block>*:not(.editor-only) {
     padding-left: 1.25rem;
+    box-sizing: border-box;
 }
 
 .block:hover .drag-handler {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1305,7 +1305,7 @@ td::placeholder {
     gap: 10px;
     padding: 5px;
     padding-left: 10px;
-    padding-right: 10px;
+    padding-right: 0;
     transition: visibility 0.2s;
 
     /* Position the toolbar outside of the block so it doesn't overlap content */

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -268,6 +268,10 @@ p.johannes-content-element {
     max-width: 100%;
 }
 
+.block.with-caption {
+    flex-direction: column;
+}
+
 .block>*:not(.editor-only) {
     padding-left: 1.25rem;
 }

--- a/src/builders/BlockToolboxBuilder.ts
+++ b/src/builders/BlockToolboxBuilder.ts
@@ -96,6 +96,8 @@ export class BlockToolboxBuilder {
         list.append(new DropdownMenuListItemTitle(list, "More options"));
         list.append(new DropdownMenuListItem("duplicateOption" + Utils.generateUniqueId(), list, Commands.duplicateBlock, null, SVGIcon.create(Icons.Duplicate, Sizes.large).htmlElement, "Clone", "Ctrl+D"));
 
+        list.append(new DropdownMenuListItem("captionOption" + Utils.generateUniqueId(), list, Commands.toggleBlockCaption, null, SVGIcon.create(Icons.Callout, Sizes.large).htmlElement, "Caption"));
+
 
         const deleteItem = new DropdownMenuListItem("deleteOption" + Utils.generateUniqueId(), list, Commands.deleteBlock, null, SVGIcon.create(Icons.Trash, Sizes.large).htmlElement, "Delete", "Shift+Del");
         deleteItem.addCssClass("danger-option");

--- a/src/commands/CommandDispatcher.ts
+++ b/src/commands/CommandDispatcher.ts
@@ -263,6 +263,13 @@ export class CommandDispatcher {
                 this.blockOperationsService.execChangeCalloutBackground(block, value);
                 break;
 
+            case Commands.toggleBlockCaption:
+                if (!block) {
+                    block = DOMUtils.getCurrentActiveBlock() as HTMLElement;
+                }
+                this.blockOperationsService.toggleCaption(block as HTMLElement);
+                break;
+
             case Commands.removeColumn:
                 this.tableOperationsService.removeColumn();
                 break;

--- a/src/commands/Commands.ts
+++ b/src/commands/Commands.ts
@@ -52,5 +52,7 @@ export enum Commands {
 
 
 
-    changeCodeBlockLanguage = "changeCodeBlockLanguage"
+    changeCodeBlockLanguage = "changeCodeBlockLanguage",
+
+    toggleBlockCaption = "toggleBlockCaption"
 }

--- a/src/components/block-toolbox/BlockToolbox.ts
+++ b/src/components/block-toolbox/BlockToolbox.ts
@@ -274,7 +274,6 @@ export class BlockToolbox implements IBlockToolbox {
         const htmlElementWrapper = document.createElement("div");
 
         htmlElementWrapper.classList.add("block-toolbar-wrapper", "exclude-from-clone", CommonClasses.EditorOnly);
-        htmlElementWrapper.style.position = "relative";
 
         const htmlElement = document.createElement("div");
         htmlElement.classList.add("block-toolbar", "soft-box-shadow");

--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -290,12 +290,13 @@ export class Content extends BaseUIComponent {
                             command: Commands.deleteBlockAndFocusOnPrevious,
                         }
                     }));
-                } else if (target.tagName === 'FIGCAPTION' && target.textContent?.trim() === '') {
+                } else if ((target.tagName === 'FIGCAPTION' || target.classList.contains('block-caption')) && target.textContent?.trim() === '') {
 
                     event.stopImmediatePropagation();
-                    const parentFigure = target.closest('figure');
+                    const parentFigure = target.tagName === 'FIGCAPTION' ? target.closest('figure') : null;
+                    const focusTarget = parentFigure?.querySelector('img, iframe, pre, div') as HTMLElement || target.previousElementSibling as HTMLElement;
                     target.remove();
-                    (parentFigure?.querySelector('img, iframe, pre, div') as HTMLElement)?.focus();
+                    focusTarget?.focus();
 
                 } else if (target.closest(".johannes-content-element") && target.textContent?.trim() === '') {
 
@@ -337,12 +338,13 @@ export class Content extends BaseUIComponent {
                             command: Commands.deleteBlockAndFocusOnNext,
                         }
                     }));
-                } else if (target.tagName === 'FIGCAPTION' && target.textContent?.trim() === '') {
+                } else if ((target.tagName === 'FIGCAPTION' || target.classList.contains('block-caption')) && target.textContent?.trim() === '') {
 
                     event.stopImmediatePropagation();
-                    const parentFigure = target.closest('figure');
+                    const parentFigure = target.tagName === 'FIGCAPTION' ? target.closest('figure') : null;
+                    const focusTarget = parentFigure?.querySelector('img, iframe, pre, div') as HTMLElement || target.previousElementSibling as HTMLElement;
                     target.remove();
-                    (parentFigure?.querySelector('img, iframe, pre, div') as HTMLElement)?.focus();
+                    focusTarget?.focus();
 
                 } else if (target.classList.contains('johannes-content-element') && target.textContent?.trim() === '') {
                     event.stopImmediatePropagation();

--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -290,6 +290,13 @@ export class Content extends BaseUIComponent {
                             command: Commands.deleteBlockAndFocusOnPrevious,
                         }
                     }));
+                } else if (target.tagName === 'FIGCAPTION' && target.textContent?.trim() === '') {
+
+                    event.stopImmediatePropagation();
+                    const parentFigure = target.closest('figure');
+                    target.remove();
+                    (parentFigure?.querySelector('img, iframe, pre, div') as HTMLElement)?.focus();
+
                 } else if (target.closest(".johannes-content-element") && target.textContent?.trim() === '') {
 
                     event.stopImmediatePropagation();
@@ -330,6 +337,13 @@ export class Content extends BaseUIComponent {
                             command: Commands.deleteBlockAndFocusOnNext,
                         }
                     }));
+                } else if (target.tagName === 'FIGCAPTION' && target.textContent?.trim() === '') {
+
+                    event.stopImmediatePropagation();
+                    const parentFigure = target.closest('figure');
+                    target.remove();
+                    (parentFigure?.querySelector('img, iframe, pre, div') as HTMLElement)?.focus();
+
                 } else if (target.classList.contains('johannes-content-element') && target.textContent?.trim() === '') {
                     event.stopImmediatePropagation();
 

--- a/src/core/EmbedTool.ts
+++ b/src/core/EmbedTool.ts
@@ -21,13 +21,7 @@ export class EmbedTool {
         image.src = url.toString();
         image.alt = '';
 
-        const figcaption = document.createElement('figcaption');
-        figcaption.setAttribute("data-placeholder", "Type a caption for this image");
-        figcaption.setAttribute("contenteditable", "true");
-        figcaption.classList.add("editable", "hide-turninto", "hide-moreoptions", "hide-inlineCode");
-
         figContent.appendChild(image);
-        figContent.appendChild(figcaption);
 
         container.appendChild(figContent);
 

--- a/src/services/block-operations/BlockOperationsService.ts
+++ b/src/services/block-operations/BlockOperationsService.ts
@@ -1263,6 +1263,12 @@ export class BlockOperationsService implements IBlockOperationsService {
                 }
             }
 
+            if (block.querySelector('.block-caption')) {
+                block.classList.add('with-caption');
+            } else {
+                block.classList.remove('with-caption');
+            }
+
             EventEmitter.emitDocChangedEvent();
             return;
         }
@@ -1276,6 +1282,12 @@ export class BlockOperationsService implements IBlockOperationsService {
             caption.setAttribute('data-placeholder', 'Type a caption');
             caption.setAttribute('contenteditable', 'true');
             block.appendChild(caption);
+        }
+
+        if (block.querySelector('.block-caption')) {
+            block.classList.add('with-caption');
+        } else {
+            block.classList.remove('with-caption');
         }
 
         EventEmitter.emitDocChangedEvent();

--- a/src/services/block-operations/BlockOperationsService.ts
+++ b/src/services/block-operations/BlockOperationsService.ts
@@ -1232,4 +1232,39 @@ export class BlockOperationsService implements IBlockOperationsService {
 
         EventEmitter.emitDocChangedEvent();
     }
+
+    toggleCaption(block: HTMLElement): void {
+
+        this.memento.saveState();
+
+        const figure = block.querySelector('figure');
+        if (figure) {
+            const existingCaption = figure.querySelector('figcaption');
+            if (existingCaption) {
+                existingCaption.remove();
+            } else {
+                const caption = document.createElement('figcaption');
+                caption.setAttribute('data-placeholder', 'Type a caption');
+                caption.setAttribute('contenteditable', 'true');
+                caption.classList.add('editable', 'hide-turninto', 'hide-moreoptions', 'hide-inlineCode');
+                figure.appendChild(caption);
+            }
+
+            EventEmitter.emitDocChangedEvent();
+            return;
+        }
+
+        const existing = block.querySelector('.block-caption');
+        if (existing) {
+            existing.remove();
+        } else {
+            const caption = document.createElement('div');
+            caption.classList.add('block-caption', 'editable', 'focusable', 'hide-turninto', 'hide-moreoptions', 'hide-inlineCode');
+            caption.setAttribute('data-placeholder', 'Type a caption');
+            caption.setAttribute('contenteditable', 'true');
+            block.appendChild(caption);
+        }
+
+        EventEmitter.emitDocChangedEvent();
+    }
 }

--- a/src/services/block-operations/BlockOperationsService.ts
+++ b/src/services/block-operations/BlockOperationsService.ts
@@ -1239,15 +1239,28 @@ export class BlockOperationsService implements IBlockOperationsService {
 
         const figure = block.querySelector('figure');
         if (figure) {
-            const existingCaption = figure.querySelector('figcaption');
-            if (existingCaption) {
-                existingCaption.remove();
+            if (figure.querySelector('.figure-content')) {
+                const existingCaption = figure.querySelector('figcaption');
+                if (existingCaption) {
+                    existingCaption.remove();
+                } else {
+                    const caption = document.createElement('figcaption');
+                    caption.setAttribute('data-placeholder', 'Type a caption');
+                    caption.setAttribute('contenteditable', 'true');
+                    caption.classList.add('editable', 'hide-turninto', 'hide-moreoptions', 'hide-inlineCode');
+                    figure.appendChild(caption);
+                }
             } else {
-                const caption = document.createElement('figcaption');
-                caption.setAttribute('data-placeholder', 'Type a caption');
-                caption.setAttribute('contenteditable', 'true');
-                caption.classList.add('editable', 'hide-turninto', 'hide-moreoptions', 'hide-inlineCode');
-                figure.appendChild(caption);
+                const next = figure.nextElementSibling;
+                if (next && next.classList.contains('block-caption')) {
+                    next.remove();
+                } else {
+                    const caption = document.createElement('div');
+                    caption.classList.add('block-caption', 'editable', 'focusable', 'hide-turninto', 'hide-moreoptions', 'hide-inlineCode');
+                    caption.setAttribute('data-placeholder', 'Type a caption');
+                    caption.setAttribute('contenteditable', 'true');
+                    figure.insertAdjacentElement('afterend', caption);
+                }
             }
 
             EventEmitter.emitDocChangedEvent();


### PR DESCRIPTION
## Summary
- remove default caption from image embeds
- support captions via new `toggleBlockCaption` command
- add caption option in "More options" menu
- handle deleting empty captions without removing figures
- style block captions consistently

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844981f25c08332992cf224482aa860