### PR TITLE
Ensure placeholder display for callout and code blocks

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -314,6 +314,14 @@ p.johannes-content-element {
     display: block;
 }
 
+/* Always show placeholders for callout and code block */
+.callout-text[data-placeholder]:empty:before,
+.code-block code[data-placeholder]:empty:before {
+    content: attr(data-placeholder);
+    color: #84888acd;
+    display: block;
+}
+
 #johannesEditor li.div[contenteditable="true"]:empty:hover:before {
     content: attr(data-placeholder);
     color: #84888acd;

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -314,12 +314,10 @@ p.johannes-content-element {
     display: block;
 }
 
-/* Always show placeholders for callout and code block */
 .callout-text[data-placeholder]:empty:before,
 .code-block code[data-placeholder]:empty:before {
-    content: attr(data-placeholder);
-    color: #84888acd;
-    display: block;
+    content: attr(data-placeholder) !important;
+    display: block !important;
 }
 
 #johannesEditor li.div[contenteditable="true"]:empty:hover:before {


### PR DESCRIPTION
## Summary
- always show placeholder text on empty callouts and code blocks

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844a818a4748332bdec90d655fccf9e