### PR TITLE
Add caption restriction to images only

### DIFF
--- a/src/builders/BlockToolboxBuilder.ts
+++ b/src/builders/BlockToolboxBuilder.ts
@@ -96,7 +96,16 @@ export class BlockToolboxBuilder {
         list.append(new DropdownMenuListItemTitle(list, "More options"));
         list.append(new DropdownMenuListItem("duplicateOption" + Utils.generateUniqueId(), list, Commands.duplicateBlock, null, SVGIcon.create(Icons.Duplicate, Sizes.large).htmlElement, "Clone", "Ctrl+D"));
 
-        list.append(new DropdownMenuListItem("captionOption" + Utils.generateUniqueId(), list, Commands.toggleBlockCaption, null, SVGIcon.create(Icons.Callout, Sizes.large).htmlElement, "Caption"));
+        const captionItem = new DropdownMenuListItem(
+            "captionOption" + Utils.generateUniqueId(),
+            list,
+            Commands.toggleBlockCaption,
+            null,
+            SVGIcon.create(Icons.Callout, Sizes.large).htmlElement,
+            "Caption"
+        );
+        captionItem.addCssClass("caption-option-item");
+        list.append(captionItem);
 
 
         const deleteItem = new DropdownMenuListItem("deleteOption" + Utils.generateUniqueId(), list, Commands.deleteBlock, null, SVGIcon.create(Icons.Trash, Sizes.large).htmlElement, "Delete", "Shift+Del");

--- a/src/components/block-toolbox/BlockToolbox.test.ts
+++ b/src/components/block-toolbox/BlockToolbox.test.ts
@@ -1,0 +1,74 @@
+import { BlockToolbox } from './BlockToolbox';
+import { ToolboxOptions } from './ToolboxOptions';
+import { ContentTypes } from '@/common/ContentTypes';
+
+describe('BlockToolbox caption option visibility', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    function setupBlock(type: ContentTypes, withImage: boolean, withPlaceholder = false): HTMLElement {
+        const block = document.createElement('div');
+        block.className = 'block deletable';
+
+        const content = document.createElement('div');
+        content.classList.add('johannes-content-element', ToolboxOptions.IncludeBlockToolbarClass, ToolboxOptions.ExtraOptionsClass);
+        content.setAttribute('data-content-type', type);
+
+        if (withPlaceholder) {
+            const placeholder = document.createElement('div');
+            placeholder.className = 'content-placeholder';
+            content.appendChild(placeholder);
+        }
+
+        if (withImage) {
+            const figure = document.createElement('figure');
+            const figContent = document.createElement('div');
+            figContent.className = 'figure-content';
+            const img = document.createElement('img');
+            figContent.appendChild(img);
+            figure.appendChild(figContent);
+            content.appendChild(figure);
+        } else if (!withPlaceholder) {
+            const figure = document.createElement('figure');
+            figure.className = 'embed-container';
+            const iframe = document.createElement('iframe');
+            figure.appendChild(iframe);
+            content.appendChild(figure);
+        }
+
+        block.appendChild(content);
+        document.body.appendChild(block);
+        return block;
+    }
+
+    test('hides caption option for non-image blocks', () => {
+        const block = setupBlock(ContentTypes.Iframe, false);
+        const content = block.querySelector('.johannes-content-element') as HTMLElement;
+        const event = { target: content } as unknown as MouseEvent;
+        BlockToolbox.getInstance().insertToolboxIntoBlockOnce(event);
+
+        const captionItem = block.querySelector('.caption-option-item') as HTMLElement;
+        expect(captionItem.style.display).toBe('none');
+    });
+
+    test('hides caption option for image placeholders', () => {
+        const block = setupBlock(ContentTypes.Image, false, true);
+        const content = block.querySelector('.johannes-content-element') as HTMLElement;
+        const event = { target: content } as unknown as MouseEvent;
+        BlockToolbox.getInstance().insertToolboxIntoBlockOnce(event);
+
+        const captionItem = block.querySelector('.caption-option-item') as HTMLElement;
+        expect(captionItem.style.display).toBe('none');
+    });
+
+    test('shows caption option for image blocks with img', () => {
+        const block = setupBlock(ContentTypes.Image, true);
+        const content = block.querySelector('.johannes-content-element') as HTMLElement;
+        const event = { target: content } as unknown as MouseEvent;
+        BlockToolbox.getInstance().insertToolboxIntoBlockOnce(event);
+
+        const captionItem = block.querySelector('.caption-option-item') as HTMLElement;
+        expect(captionItem.style.display).toBe('flex');
+    });
+});

--- a/src/components/block-toolbox/BlockToolbox.ts
+++ b/src/components/block-toolbox/BlockToolbox.ts
@@ -6,6 +6,7 @@ import { DOMElements } from "@/common/DOMElements";
 import { CommonClasses } from "@/common/CommonClasses";
 import { DOMUtils } from "@/utilities/DOMUtils";
 import { Utils } from "@/utilities/Utils";
+import { ContentTypes } from "@/common/ContentTypes";
 
 export class BlockToolbox implements IBlockToolbox {
 
@@ -162,6 +163,7 @@ export class BlockToolbox implements IBlockToolbox {
 
             if (block) {
                 block.appendChild(toolboxWrapper);
+                BlockToolbox.updateCaptionOptionVisibility(block as HTMLElement);
                 block.addEventListener(DefaultJSEvents.Mouseenter, (event) => this.resetToolbox(event, block as HTMLElement));
 
                 block.addEventListener(DefaultJSEvents.Mousemove, (event: Event) => {
@@ -248,6 +250,21 @@ export class BlockToolbox implements IBlockToolbox {
         return false;
     }
 
+    static updateCaptionOptionVisibility(block: HTMLElement): void {
+        const captionItem = block.querySelector('.caption-option-item') as HTMLElement | null;
+        if (!captionItem) return;
+
+        const contentElement = block.querySelector('.johannes-content-element') as HTMLElement | null;
+        const contentType = contentElement?.getAttribute('data-content-type');
+        const hasImage = !!block.querySelector('img');
+
+        if (contentType === ContentTypes.Image && hasImage) {
+            captionItem.style.display = 'flex';
+        } else {
+            captionItem.style.display = 'none';
+        }
+    }
+
     resetToolbox(event: Event, block: HTMLElement) {
         const blockToolbar = block.querySelector(".block-toolbar");
 
@@ -267,6 +284,7 @@ export class BlockToolbox implements IBlockToolbox {
         }
 
         this.changeToolbarColor(block);
+        BlockToolbox.updateCaptionOptionVisibility(block);
     }
 
     static createToolbox(includeLanguageSelectionTool = false, includeAlignTool = false, includeColorTool = false, includeExtraOptions = false): HTMLElement {

--- a/src/services/block-operations/BlockOperationsService.test.ts
+++ b/src/services/block-operations/BlockOperationsService.test.ts
@@ -289,9 +289,11 @@ describe('BlockOperationsService.createNewElementAndSplitContent', () => {
             block.className = 'block deletable';
 
             const figure = document.createElement('figure');
-            figure.className = 'figure-content';
+            const figContent = document.createElement('div');
+            figContent.className = 'figure-content';
             const img = document.createElement('img');
-            figure.appendChild(img);
+            figContent.appendChild(img);
+            figure.appendChild(figContent);
             const caption = document.createElement('figcaption');
             caption.className = 'editable';
             caption.contentEditable = 'true';
@@ -323,9 +325,11 @@ describe('BlockOperationsService.createNewElementAndSplitContent', () => {
             block.className = 'block deletable';
 
             const figure = document.createElement('figure');
-            figure.className = 'figure-content';
+            const figContent = document.createElement('div');
+            figContent.className = 'figure-content';
             const img = document.createElement('img');
-            figure.appendChild(img);
+            figContent.appendChild(img);
+            figure.appendChild(figContent);
             const caption = document.createElement('figcaption');
             caption.className = 'editable';
             caption.contentEditable = 'true';
@@ -367,6 +371,56 @@ describe('BlockOperationsService.createNewElementAndSplitContent', () => {
             service.deleteTheCurrentElementAndTheDraggableBlockIfEmpty(content);
 
             expect(document.body.contains(block)).toBe(false);
+        });
+    });
+
+    describe('toggleCaption', () => {
+        test('should add caption for image blocks', () => {
+            const block = document.createElement('div');
+            block.className = 'block deletable';
+
+            const content = document.createElement('div');
+            content.className = 'johannes-content-element';
+            content.setAttribute('data-content-type', ContentTypes.Image);
+
+            const figure = document.createElement('figure');
+            const figContent = document.createElement('div');
+            figContent.className = 'figure-content';
+            const img = document.createElement('img');
+            figContent.appendChild(img);
+            figure.appendChild(figContent);
+
+            content.appendChild(figure);
+            block.appendChild(content);
+            document.body.appendChild(block);
+
+            service.toggleCaption(block);
+
+            const caption = block.querySelector('figcaption');
+            expect(caption).not.toBeNull();
+        });
+
+        test('should not add caption for non-image blocks', () => {
+            const block = document.createElement('div');
+            block.className = 'block deletable';
+
+            const content = document.createElement('div');
+            content.className = 'johannes-content-element';
+            content.setAttribute('data-content-type', ContentTypes.Iframe);
+
+            const figure = document.createElement('figure');
+            figure.className = 'embed-container';
+            const iframe = document.createElement('iframe');
+            figure.appendChild(iframe);
+
+            content.appendChild(figure);
+            block.appendChild(content);
+            document.body.appendChild(block);
+
+            service.toggleCaption(block);
+
+            const caption = block.querySelector('figcaption, .block-caption');
+            expect(caption).toBeNull();
         });
     });
 

--- a/src/services/block-operations/BlockOperationsService.ts
+++ b/src/services/block-operations/BlockOperationsService.ts
@@ -1276,6 +1276,13 @@ export class BlockOperationsService implements IBlockOperationsService {
 
     toggleCaption(block: HTMLElement): void {
 
+        const contentElement = block.querySelector('.johannes-content-element') as HTMLElement | null;
+        const contentType = contentElement?.getAttribute('data-content-type');
+
+        if (contentType !== ContentTypes.Image) {
+            return;
+        }
+
         this.memento.saveState();
 
         const moreOptionsList = block.querySelector('.media-more-option-select') as HTMLElement | null;


### PR DESCRIPTION
## Summary
- add a content type check so only images can toggle captions
- add tests verifying caption is added only for images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845c79f2b4483328b50f02ae9267c30