### PR TITLE
Fix arrow navigation at document boundaries

### DIFF
--- a/src/core/EditableNavigation.ts
+++ b/src/core/EditableNavigation.ts
@@ -52,11 +52,11 @@ export class EditableNavigation implements IEditableNavigation {
             if (currentEditable && currentEditable.isContentEditable) {
                 if (this.shouldSwitchEditable(currentEditable, event.key as Directions)) {
 
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
+
                     const nextEditable = this.findNextEditable(currentEditable, event.key as Directions);
                     if (nextEditable) {
-
-                        event.preventDefault();
-                        event.stopImmediatePropagation();
 
                         if (event.key == Directions.ArrowUp || event.key == Directions.ArrowDown) {
                             const refRect = EditableNavigation.getCaretRect();


### PR DESCRIPTION
## Summary
- keep caret at first/last editable when navigating with arrow keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845d30e6600833281e4bfc39845a3fd