### PR TITLE
Fix block duplication of empty paragraphs

### DIFF
--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -404,6 +404,10 @@ export class Content extends BaseUIComponent {
 
         if (target instanceof HTMLElement && target.contentEditable === "true") {
             DOMUtils.sanitizeContentEditable(target);
+            const block = target.closest('.block');
+            if (block) {
+                DOMUtils.removeExtraEmptyContentElements(block as HTMLElement);
+            }
         }
     }
 

--- a/src/utilities/DOMUtils.test.ts
+++ b/src/utilities/DOMUtils.test.ts
@@ -1518,3 +1518,27 @@ describe("DOMUtils.getCurrentActiveBlock", () => {
         expect(block).toBeNull();
     });
 });
+
+describe("DOMUtils.removeExtraEmptyContentElements", () => {
+    test("should remove empty additional content elements", () => {
+        const block = document.createElement("div");
+        block.className = "block";
+
+        const first = document.createElement("p");
+        first.className = "johannes-content-element";
+        first.setAttribute("contenteditable", "true");
+        first.textContent = "Hello";
+
+        const second = document.createElement("p");
+        second.className = "johannes-content-element";
+        second.setAttribute("contenteditable", "true");
+        second.innerHTML = "<br>";
+
+        block.appendChild(first);
+        block.appendChild(second);
+
+        DOMUtils.removeExtraEmptyContentElements(block);
+
+        expect(block.querySelectorAll(".johannes-content-element").length).toBe(1);
+    });
+});

--- a/src/utilities/DOMUtils.ts
+++ b/src/utilities/DOMUtils.ts
@@ -1,4 +1,5 @@
 import { Utils } from "./Utils";
+import { CommonClasses } from "@/common/CommonClasses";
 
 const START_MARKER_ID = 'caret-start-marker';
 const END_MARKER_ID = 'caret-end-marker';
@@ -630,6 +631,18 @@ export class DOMUtils {
         } else {
             element.removeAttribute('data-empty');
         }
+    }
+
+    static removeExtraEmptyContentElements(block: HTMLElement): void {
+        const contentElements = block.querySelectorAll(`.${CommonClasses.ContentElement}`);
+        contentElements.forEach((el, index) => {
+            if (index === 0) return;
+            const html = (el as HTMLElement).innerHTML.replace(/\u200B/g, '').trim();
+            const text = (el as HTMLElement).textContent?.trim() || '';
+            if (html === '' || html === '<br>' || text === '') {
+                el.remove();
+            }
+        });
     }
 
     static isTargetDescendantOfSelector(event: Event, selector: string): boolean {


### PR DESCRIPTION
## Summary
- remove empty paragraphs left in blocks
- sanitize blocks on blur events
- test removal of extra empty paragraphs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845d3d3eb948332ba7c7501912868b7