### PR TITLE
Fix drag handler visibility on empty blocks

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -296,6 +296,10 @@ p.johannes-content-element {
     box-sizing: border-box;
 }
 
+.block:empty {
+    min-height: 1.5rem;
+}
+
 .block:hover .drag-handler,
 .block:focus-within .drag-handler {
     visibility: visible;

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -296,7 +296,8 @@ p.johannes-content-element {
     box-sizing: border-box;
 }
 
-.block:hover .drag-handler {
+.block:hover .drag-handler,
+.block:focus-within .drag-handler {
     visibility: visible;
     vertical-align: top;
     justify-content: start;


### PR DESCRIPTION
## Summary
- show drag handle when the block or its children have focus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845d73c790c83328225f160939e55b8