### PR TITLE
Fix content wrapper editability

### DIFF
--- a/src/components/content/Content.test.ts
+++ b/src/components/content/Content.test.ts
@@ -38,4 +38,39 @@ describe("Content", () => {
     const content = Content.getInstance();
     expect(content).toBeInstanceOf(Content);
   });
+
+  test("handleSelectionChange removes wrapper editability once selection collapses", () => {
+    document.body.innerHTML = `
+      <div id="johannesEditor">
+        <div class="content-wrapper">
+          <p contenteditable="true">Hello</p>
+        </div>
+      </div>`;
+
+    const content = Content.getInstance();
+    const wrapper = document.querySelector(".content-wrapper") as HTMLElement;
+    const p = wrapper.querySelector("p") as HTMLElement;
+
+    const range = document.createRange();
+    range.setStart(p.firstChild!, 0);
+    range.setEnd(p.firstChild!, p.textContent!.length);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+
+    content.handleSelectionChange();
+
+    expect(wrapper.getAttribute("contenteditable")).toBe("true");
+
+    // Collapse selection
+    sel?.removeAllRanges();
+    const collapsedRange = document.createRange();
+    collapsedRange.setStart(p.firstChild!, 1);
+    collapsedRange.setEnd(p.firstChild!, 1);
+    sel?.addRange(collapsedRange);
+
+    content.handleSelectionChange();
+
+    expect(wrapper.getAttribute("contenteditable")).toBeNull();
+  });
 });

--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -102,6 +102,9 @@ export class Content extends BaseUIComponent {
             }
         } else if (this.contentWrapper &&
             this.contentWrapper.getAttribute("contenteditable") === "true") {
+            // Remove editing capabilities as soon as the selection collapses
+            this.contentWrapper.removeAttribute("contenteditable");
+            // Fallback removal in case focus leaves the editor with attribute still set
             setTimeout(() => {
                 if (!Content.isFocusInsideEditor()) {
                     this.contentWrapper?.removeAttribute("contenteditable");


### PR DESCRIPTION
## Summary
- disable editing on `.content-wrapper` immediately when the selection collapses
- add regression test for collapsed selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845cf85d2cc83328ffc6579287316b0