### PR TITLE
Fix add block after deleting content

### DIFF
--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -239,6 +239,31 @@ export class Content extends BaseUIComponent {
                 return;
             }
 
+            if ((event.key === KeyboardKeys.Backspace || event.key === KeyboardKeys.Delete)) {
+                const selection = document.getSelection();
+                const title = document.querySelector('#johannesEditor .title');
+                if (selection && selection.rangeCount > 0 && !selection.isCollapsed && title) {
+                    const range = selection.getRangeAt(0);
+                    const intersectsTitle = range.intersectsNode(title) ||
+                        title.contains(range.startContainer) ||
+                        title.contains(range.endContainer);
+                    if (intersectsTitle) {
+                        event.preventDefault();
+                        const content = document.querySelector('#johannesEditor .content') as HTMLElement | null;
+                        content?.querySelectorAll('.block').forEach(b => b.remove());
+                        const h1 = title.querySelector('h1');
+                        if (h1) {
+                            const newRange = document.createRange();
+                            newRange.selectNodeContents(h1);
+                            newRange.collapse(false);
+                            selection.removeAllRanges();
+                            selection.addRange(newRange);
+                        }
+                        return;
+                    }
+                }
+            }
+
             if (event.ctrlKey || event.shiftKey || event.altKey) {
                 return;
             }

--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -85,13 +85,7 @@ export class Content extends BaseUIComponent {
 
         if (selection && selection.rangeCount > 0 && !selection.isCollapsed) {
             const range = selection.getRangeAt(0).cloneRange();
-            const title = document.querySelector('#johannesEditor .title');
-            const intersectsTitle = title &&
-                (range.intersectsNode(title) ||
-                 title.contains(range.startContainer) ||
-                 title.contains(range.endContainer));
-
-            if (!intersectsTitle && this.contentWrapper && this.contentWrapper.getAttribute("contenteditable") !== "true") {
+            if (this.contentWrapper && this.contentWrapper.getAttribute("contenteditable") !== "true") {
 
                 this.contentWrapper.setAttribute("contenteditable", "true");
 
@@ -239,30 +233,7 @@ export class Content extends BaseUIComponent {
                 return;
             }
 
-            if ((event.key === KeyboardKeys.Backspace || event.key === KeyboardKeys.Delete)) {
-                const selection = document.getSelection();
-                const title = document.querySelector('#johannesEditor .title');
-                if (selection && selection.rangeCount > 0 && !selection.isCollapsed && title) {
-                    const range = selection.getRangeAt(0);
-                    const intersectsTitle = range.intersectsNode(title) ||
-                        title.contains(range.startContainer) ||
-                        title.contains(range.endContainer);
-                    if (intersectsTitle) {
-                        event.preventDefault();
-                        const content = document.querySelector('#johannesEditor .content') as HTMLElement | null;
-                        content?.querySelectorAll('.block').forEach(b => b.remove());
-                        const h1 = title.querySelector('h1');
-                        if (h1) {
-                            const newRange = document.createRange();
-                            newRange.selectNodeContents(h1);
-                            newRange.collapse(false);
-                            selection.removeAllRanges();
-                            selection.addRange(newRange);
-                        }
-                        return;
-                    }
-                }
-            }
+
 
             if (event.ctrlKey || event.shiftKey || event.altKey) {
                 return;

--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -84,7 +84,14 @@ export class Content extends BaseUIComponent {
         const selection = document.getSelection();
 
         if (selection && selection.rangeCount > 0 && !selection.isCollapsed) {
-            if (this.contentWrapper && this.contentWrapper.getAttribute("contenteditable") !== "true") {
+            const range = selection.getRangeAt(0);
+            const title = document.querySelector('#johannesEditor .title');
+            const intersectsTitle = title &&
+                (range.intersectsNode(title) ||
+                 title.contains(range.startContainer) ||
+                 title.contains(range.endContainer));
+
+            if (!intersectsTitle && this.contentWrapper && this.contentWrapper.getAttribute("contenteditable") !== "true") {
                 const anchorNode = selection.anchorNode;
                 const anchorOffset = selection.anchorOffset;
                 const focusNode = selection.focusNode;

--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -85,6 +85,13 @@ export class Content extends BaseUIComponent {
 
         if (selection && selection.rangeCount > 0 && !selection.isCollapsed) {
             const range = selection.getRangeAt(0).cloneRange();
+            const title = document.querySelector('#johannesEditor .title');
+
+            // Prevent turning the wrapper editable when the selection includes the title
+            if (title && range.intersectsNode(title)) {
+                return;
+            }
+
             if (this.contentWrapper && this.contentWrapper.getAttribute("contenteditable") !== "true") {
 
                 this.contentWrapper.setAttribute("contenteditable", "true");

--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -84,7 +84,7 @@ export class Content extends BaseUIComponent {
         const selection = document.getSelection();
 
         if (selection && selection.rangeCount > 0 && !selection.isCollapsed) {
-            const range = selection.getRangeAt(0);
+            const range = selection.getRangeAt(0).cloneRange();
             const title = document.querySelector('#johannesEditor .title');
             const intersectsTitle = title &&
                 (range.intersectsNode(title) ||
@@ -92,10 +92,6 @@ export class Content extends BaseUIComponent {
                  title.contains(range.endContainer));
 
             if (!intersectsTitle && this.contentWrapper && this.contentWrapper.getAttribute("contenteditable") !== "true") {
-                const anchorNode = selection.anchorNode;
-                const anchorOffset = selection.anchorOffset;
-                const focusNode = selection.focusNode;
-                const focusOffset = selection.focusOffset;
 
                 this.contentWrapper.setAttribute("contenteditable", "true");
 
@@ -103,7 +99,7 @@ export class Content extends BaseUIComponent {
                     const newSelection = document.getSelection();
                     if (newSelection) {
                         newSelection.removeAllRanges();
-                        newSelection.setBaseAndExtent(anchorNode!, anchorOffset, focusNode!, focusOffset);
+                        newSelection.addRange(range);
                     }
                 }, 0);
             }

--- a/src/components/editor/Editor.test.ts
+++ b/src/components/editor/Editor.test.ts
@@ -1,5 +1,9 @@
 import { DOMUtils } from '@/utilities/DOMUtils';
 import { Editor } from './Editor';
+import { EditorBuilder } from '@/builders/EditorBuilder';
+import { DependencyContainer } from '@/core/DependencyContainer';
+import { ElementFactoryService } from '@/services/element-factory/ElementFactoryService';
+import { registerEditorDependenciesForTests } from '../../../tests/helpers/registerEditorDependencies';
 import { IBlockOperationsService } from '@/services/block-operations/IBlockOperationsService';
 import { Utils } from '@/utilities/Utils';
 
@@ -224,5 +228,30 @@ describe('Editor.handlePasteEvent', () => {
         Editor.handlePasteEvent(clipboardEvent, blockOperationsService);
 
         expect(insertTextAtCursor).toHaveBeenCalledWith('bold');
+    });
+});
+
+describe('Editor structure monitoring', () => {
+    let editor: Editor;
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="johannesEditor"></div>';
+        registerEditorDependenciesForTests();
+        DependencyContainer.Instance.register('IElementFactoryService', () => ElementFactoryService.getInstance());
+        editor = EditorBuilder.build();
+    });
+
+    test('recreates title and first paragraph when removed', (done) => {
+        const wrapper = document.querySelector('#johannesEditor .content-wrapper') as HTMLElement;
+        const title = wrapper.querySelector('.title') as HTMLElement;
+        const first = wrapper.querySelector('.content .block') as HTMLElement;
+
+        title.remove();
+        first.remove();
+
+        setTimeout(() => {
+            expect(wrapper.querySelector('.title')).not.toBeNull();
+            expect(wrapper.querySelector('.content .block')).not.toBeNull();
+            done();
+        }, 0);
     });
 });

--- a/src/components/editor/Editor.ts
+++ b/src/components/editor/Editor.ts
@@ -229,8 +229,30 @@ export class Editor extends BaseUIComponent {
             wrapper.appendChild(content);
         }
 
+        // Move any stray blocks directly under the wrapper back into the content container
+        wrapper.querySelectorAll(':scope > .block').forEach(block => {
+            content!.appendChild(block);
+        });
+
         if (!content.querySelector('.block')) {
             content.appendChild(ElementFactoryService.blockParagraph());
+        }
+
+        // Ensure every block has an editable content element
+        content.querySelectorAll('.block').forEach(block => {
+            const editable = block.querySelector('.johannes-content-element') as HTMLElement | null;
+            if (editable && editable.getAttribute('contenteditable') !== 'true') {
+                editable.setAttribute('contenteditable', 'true');
+            }
+        });
+
+        // Remove duplicate empty blocks leaving only one
+        const blocks = content.querySelectorAll('.block');
+        if (blocks.length > 1) {
+            const empties = Array.from(blocks).filter(b => (b.textContent || '').trim() === '');
+            if (empties.length === blocks.length) {
+                empties.slice(1).forEach(b => b.remove());
+            }
         }
     }
 

--- a/src/services/block-operations/BlockOperationsService.ts
+++ b/src/services/block-operations/BlockOperationsService.ts
@@ -888,11 +888,19 @@ export class BlockOperationsService implements IBlockOperationsService {
         this.memento.saveState();
         const newBlock = this.elementFactoryService.create(ElementFactoryService.ELEMENT_TYPES.BLOCK_PARAGRAPH, text || "");
 
+        let contentElement = document.querySelector("#johannesEditor .content");
+        if (!contentElement) {
+            const wrapper = document.querySelector("#johannesEditor .content-wrapper");
+            contentElement = document.createElement('div');
+            contentElement.classList.add('content');
+            wrapper?.appendChild(contentElement);
+        }
+
         if (eventParagraph && eventParagraph.closest('.block')) {
             const sibling = eventParagraph.closest('.block')!;
             sibling.insertAdjacentElement('afterend', newBlock);
-        } else {
-            document.querySelector("#johannesEditor .content")!.appendChild(newBlock);
+        } else if (contentElement) {
+            contentElement.appendChild(newBlock);
         }
 
         const focusable = newBlock.querySelector('.johannes-content-element') as HTMLElement;

--- a/src/services/block-operations/BlockOperationsService.ts
+++ b/src/services/block-operations/BlockOperationsService.ts
@@ -22,6 +22,17 @@ export class BlockOperationsService implements IBlockOperationsService {
     private memento: IMemento;
     private focusStack: IFocusStack;
 
+    private getOrCreateContentElement(): HTMLElement {
+        let contentElement = document.querySelector('#johannesEditor .content') as HTMLElement | null;
+        if (!contentElement) {
+            const wrapper = document.querySelector('#johannesEditor .content-wrapper');
+            contentElement = document.createElement('div');
+            contentElement.classList.add('content');
+            wrapper?.appendChild(contentElement);
+        }
+        return contentElement as HTMLElement;
+    }
+
     private constructor(
         elementFactoryService: IElementFactoryService,
         focusStack: IFocusStack,
@@ -45,7 +56,7 @@ export class BlockOperationsService implements IBlockOperationsService {
         if (previousBlock) {
             previousBlock.insertAdjacentElement('afterend', block);
         } else {
-            document.querySelector("#johannesEditor .content")!.appendChild(block);
+            this.getOrCreateContentElement().appendChild(block);
         }
 
         return block;
@@ -869,7 +880,7 @@ export class BlockOperationsService implements IBlockOperationsService {
             p.innerHTML = clonedTitle?.innerHTML || "";
         }
 
-        const content = document.querySelector("#johannesEditor .content");
+        const content = this.getOrCreateContentElement();
 
         if (content) {
             content.prepend(newBlock);
@@ -888,13 +899,7 @@ export class BlockOperationsService implements IBlockOperationsService {
         this.memento.saveState();
         const newBlock = this.elementFactoryService.create(ElementFactoryService.ELEMENT_TYPES.BLOCK_PARAGRAPH, text || "");
 
-        let contentElement = document.querySelector("#johannesEditor .content");
-        if (!contentElement) {
-            const wrapper = document.querySelector("#johannesEditor .content-wrapper");
-            contentElement = document.createElement('div');
-            contentElement.classList.add('content');
-            wrapper?.appendChild(contentElement);
-        }
+        const contentElement = this.getOrCreateContentElement();
 
         if (eventParagraph && eventParagraph.closest('.block')) {
             const sibling = eventParagraph.closest('.block')!;


### PR DESCRIPTION
## Summary
- prevent enabling contenteditable when selection contains the title
- ensure default paragraph insertion recreates missing content container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845d839851083328112f43395e91fd4