### PR TITLE
Fix quick menu slash trigger

### DIFF
--- a/src/common/KeyboardKeys.ts
+++ b/src/common/KeyboardKeys.ts
@@ -10,5 +10,7 @@ export enum KeyboardKeys {
     ArrowRight = "ArrowRight",
     ArrowLeft = "ArrowLeft",
     ArrowDown = "ArrowDown",
-    ArrowUp = "ArrowUp"
+    ArrowUp = "ArrowUp",
+    Slash = "/"
 }
+

--- a/src/components/quick-menu/QuickMenu.ts
+++ b/src/components/quick-menu/QuickMenu.ts
@@ -311,6 +311,35 @@ export class QuickMenu extends BaseUIComponent implements IQuickMenu {
         });
 
         document.addEventListener(DefaultJSEvents.Keydown, (event: KeyboardEvent) => {
+            if (event.key !== KeyboardKeys.Slash || this.isVisible) {
+                return;
+            }
+
+            if (!Utils.isEventFromContentWrapper(event)) {
+                return;
+            }
+
+            const target = event.target as HTMLElement;
+
+            if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target.isContentEditable)) {
+                return;
+            }
+
+            const block = DOMUtils.findClosestAncestorOfActiveElementByClass("block");
+
+            if (block) {
+                const currentCell = target.closest(".ignore-quick-menu") as HTMLTableCellElement;
+
+                if (currentCell) {
+                    return;
+                }
+
+                this.filterInput = '';
+                this.show();
+            }
+        });
+
+        document.addEventListener(DefaultJSEvents.Keydown, (event: KeyboardEvent) => {
 
             if (
                 event.key !== KeyboardKeys.ArrowLeft &&


### PR DESCRIPTION
## Summary
- add `Slash` to KeyboardKeys
- ensure the quick menu opens on '/' keydown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68476dbb6cdc83328549350fef2eed33