### PR TITLE
Fix table toolbar not showing

### DIFF
--- a/src/components/floating-toolbar/table-context/Toolbar.test.ts
+++ b/src/components/floating-toolbar/table-context/Toolbar.test.ts
@@ -1,0 +1,69 @@
+import { Toolbar } from "./Toolbar";
+import { DependencyContainer } from "@/core/DependencyContainer";
+
+class MockFocusStack {
+    push = jest.fn();
+    pop = jest.fn();
+    peek = jest.fn();
+    clear = jest.fn();
+}
+
+class MockTableOperationsService {
+    queryAllStateCellBackgroundColor = jest.fn(() => false);
+}
+
+describe("TableContextFloatingToolbar", () => {
+    let toolbar: Toolbar;
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="johannesEditor">
+                <div class="content-wrapper">
+                    <table>
+                        <tbody>
+                            <tr><td id="cell1">a</td><td id="cell2">b</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div id="outside"></div>
+            </div>
+        `;
+
+        DependencyContainer.Instance.register("IFocusStack", () => new MockFocusStack());
+        DependencyContainer.Instance.register("ITableOperationsService", () => new MockTableOperationsService());
+
+        toolbar = Toolbar.getInstance();
+        document.getElementById("johannesEditor")!.appendChild(toolbar.htmlElement);
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    test("shows toolbar when mouseup occurs inside wrapper", () => {
+        const cell = document.getElementById("cell1") as HTMLTableCellElement;
+        const mousedown = new MouseEvent("mousedown", { bubbles: true });
+        Object.defineProperty(mousedown, 'target', { value: cell });
+        const mouseup = new MouseEvent("mouseup", { bubbles: true });
+        Object.defineProperty(mouseup, 'target', { value: cell });
+
+        (toolbar as any).handleMouseDown(mousedown);
+        (toolbar as any).handleMouseUp(mouseup);
+
+        expect(toolbar.isVisible).toBe(true);
+    });
+
+    test("shows toolbar when mouseup occurs outside wrapper", () => {
+        const cell = document.getElementById("cell1") as HTMLTableCellElement;
+        const outside = document.getElementById("outside") as HTMLElement;
+        const mousedown = new MouseEvent("mousedown", { bubbles: true });
+        Object.defineProperty(mousedown, 'target', { value: cell });
+        const mouseupOutside = new MouseEvent("mouseup", { bubbles: true });
+        Object.defineProperty(mouseupOutside, 'target', { value: outside });
+
+        (toolbar as any).handleMouseDown(mousedown);
+        (toolbar as any).handleMouseUp(mouseupOutside);
+
+        expect(toolbar.isVisible).toBe(true);
+    });
+});

--- a/src/components/floating-toolbar/table-context/Toolbar.test.ts
+++ b/src/components/floating-toolbar/table-context/Toolbar.test.ts
@@ -1,4 +1,5 @@
 import { Toolbar } from "./Toolbar";
+import { SelectionModes } from "./SelectionMode";
 import { DependencyContainer } from "@/core/DependencyContainer";
 
 class MockFocusStack {
@@ -64,6 +65,27 @@ describe("TableContextFloatingToolbar", () => {
         (toolbar as any).handleMouseDown(mousedown);
         (toolbar as any).handleMouseUp(mouseupOutside);
 
+        expect(toolbar.isVisible).toBe(true);
+    });
+
+    test("shows toolbar when multiple cells are selected by dragging", () => {
+        const cell1 = document.getElementById("cell1") as HTMLTableCellElement;
+        const cell2 = document.getElementById("cell2") as HTMLTableCellElement;
+
+        const mousedown = new MouseEvent("mousedown", { bubbles: true });
+        Object.defineProperty(mousedown, 'target', { value: cell1 });
+        (toolbar as any).handleMouseDown(mousedown);
+
+        (toolbar as any).selectionMode = SelectionModes.Cell;
+        const mousemove = new MouseEvent("mousemove", { bubbles: true });
+        Object.defineProperty(mousemove, 'target', { value: cell2 });
+        (toolbar as any).handleMouseMove(mousemove);
+
+        const mouseup = new MouseEvent("mouseup", { bubbles: true });
+        Object.defineProperty(mouseup, 'target', { value: cell2 });
+        (toolbar as any).handleMouseUp(mouseup);
+
+        expect((toolbar as any).selectedCells.length).toBe(2);
         expect(toolbar.isVisible).toBe(true);
     });
 });

--- a/src/components/floating-toolbar/table-context/Toolbar.ts
+++ b/src/components/floating-toolbar/table-context/Toolbar.ts
@@ -114,9 +114,9 @@ export class Toolbar extends FloatingToolbarBase implements ITableContextFloatin
     private handleMouseUp(event: MouseEvent) {
         if (this.selectedCells.length > 0 && this.selectionFlag) {
             const contentWrapper = document.querySelector('#johannesEditor .content-wrapper');
-            const focusedInsideWrapper = this.actualFocusedCell && contentWrapper?.contains(this.actualFocusedCell);
+            const cellInsideWrapper = this.selectedCells.some(cell => contentWrapper?.contains(cell));
 
-            if (!Utils.isEventFromContentWrapper(event) && !focusedInsideWrapper) {
+            if (!cellInsideWrapper) {
                 return;
             }
 

--- a/src/components/floating-toolbar/table-context/Toolbar.ts
+++ b/src/components/floating-toolbar/table-context/Toolbar.ts
@@ -51,9 +51,21 @@ export class Toolbar extends FloatingToolbarBase implements ITableContextFloatin
     }
 
     attachEvents(): void {
-        document.addEventListener(DefaultJSEvents.Mousedown, this.handleMouseDown.bind(this));
-        document.addEventListener(DefaultJSEvents.Mousemove, this.handleMouseMove.bind(this));
-        document.addEventListener(DefaultJSEvents.Mouseup, this.handleMouseUp.bind(this));
+        document.addEventListener(
+            DefaultJSEvents.Mousedown,
+            this.handleMouseDown.bind(this),
+            true
+        );
+        document.addEventListener(
+            DefaultJSEvents.Mousemove,
+            this.handleMouseMove.bind(this),
+            true
+        );
+        document.addEventListener(
+            DefaultJSEvents.Mouseup,
+            this.handleMouseUp.bind(this),
+            true
+        );
 
         document.addEventListener(DefaultJSEvents.Keydown, this.handleStartSelectionInCellKeyDown.bind(this));
         document.addEventListener(DefaultJSEvents.Keydown, this.handleCellSelectionContinuationOnKeyDown.bind(this));
@@ -113,13 +125,6 @@ export class Toolbar extends FloatingToolbarBase implements ITableContextFloatin
 
     private handleMouseUp(event: MouseEvent) {
         if (this.selectedCells.length > 0 && this.selectionFlag) {
-            const contentWrapper = document.querySelector('#johannesEditor .content-wrapper');
-            const cellInsideWrapper = this.selectedCells.some(cell => contentWrapper?.contains(cell));
-
-            if (!cellInsideWrapper) {
-                return;
-            }
-
             this.resetSelectionState();
             this.show();
         }
@@ -305,6 +310,7 @@ export class Toolbar extends FloatingToolbarBase implements ITableContextFloatin
         if (this.selectedCells.length === 0) {
             this.selectedCells.push(cell);
             cell.classList.add('selected');
+            cell.tabIndex = 0;
             this.actualFocusedCell = cell;
             cell.focus();
             return;
@@ -318,6 +324,7 @@ export class Toolbar extends FloatingToolbarBase implements ITableContextFloatin
                 if (index === -1) {
                     this.selectedCells.push(cell);
                     cell.classList.add('selected');
+                    cell.tabIndex = 0;
                     this.actualFocusedCell = cell;
                     cell.focus();
                 } else {

--- a/src/components/floating-toolbar/table-context/Toolbar.ts
+++ b/src/components/floating-toolbar/table-context/Toolbar.ts
@@ -113,8 +113,10 @@ export class Toolbar extends FloatingToolbarBase implements ITableContextFloatin
 
     private handleMouseUp(event: MouseEvent) {
         if (this.selectedCells.length > 0 && this.selectionFlag) {
+            const contentWrapper = document.querySelector('#johannesEditor .content-wrapper');
+            const focusedInsideWrapper = this.actualFocusedCell && contentWrapper?.contains(this.actualFocusedCell);
 
-            if (!Utils.isEventFromContentWrapper(event)) {
+            if (!Utils.isEventFromContentWrapper(event) && !focusedInsideWrapper) {
                 return;
             }
 


### PR DESCRIPTION
## Summary
- fix mouseup logic for table context toolbar so selection outside the wrapper still shows the toolbar
- add regression tests for table toolbar visibility on mouseup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68476b6097108332be892d2438bcf013