### PR TITLE
Fix AddBlockButton event timing

### DIFF
--- a/src/components/add-block/AddBlockButton.test.ts
+++ b/src/components/add-block/AddBlockButton.test.ts
@@ -1,97 +1,65 @@
-import { UIBuilder } from "../../builders/UIBuilder";
-import { Editor } from "../editor/Editor";
+import { AddBlockButton } from './AddBlockButton';
+import { SVGIcon } from '../common/SVGIcon';
+import { Icons } from '@/common/Icons';
+import { Sizes } from '@/common/Sizes';
+import { Commands } from '@/commands/Commands';
+import { IBlockOperationsService } from '@/services/block-operations/IBlockOperationsService';
 
+class MockBlockOperationsService implements IBlockOperationsService {
+  execCommand = jest.fn();
+  queryCommandState(): Promise<boolean> { return Promise.resolve(false); }
+  transformBlock(): void {}
+  createNewElementAndSplitContent(): boolean { return false; }
+  justifyLeft(): void {}
+  justifyCenter(): void {}
+  justifyRight(): void {}
+  changeCodeBlockLanguage(): void {}
+  createANewParagraphFromTitle(): void {}
+  execDeleteBlock(): boolean { return false; }
+  execDuplicateBlock(): boolean { return false; }
+  execDeleteFocusOnPrevious(): boolean { return false; }
+  execDeleteAndFocusOnNext(): boolean { return false; }
+  execFocusOnNext(): boolean { return false; }
+  execMergeWithPreviousBlock(): void {}
+  execMergeWithNextBlock(): void {}
+  execChangeCalloutBackground(): void {}
+  toggleCaption(): void {}
+  createDefaultBlock(): HTMLElement { return document.createElement('div'); }
+  insertBlock(): HTMLElement { return document.createElement('div'); }
+  insertLiIntoListBlock(): HTMLElement { return document.createElement('li'); }
+}
 
-describe("AddBlockButton", () => {
-    test("dummy", () => {
-        expect(true).toBe(true);
-    });
+describe('AddBlockButton', () => {
+  let service: MockBlockOperationsService;
+  let button: AddBlockButton;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    service = new MockBlockOperationsService();
+    const icon = SVGIcon.create(Icons.Plus, Sizes.medium);
+    button = new AddBlockButton(service, icon);
+    document.body.appendChild(button.htmlElement);
+  });
+
+  test('executes createDefaultBlock on pointerdown', () => {
+    const event = new Event('pointerdown', { bubbles: true });
+    button.htmlElement.dispatchEvent(event);
+
+    expect(service.execCommand).toHaveBeenCalledWith(Commands.createDefaultBlock, false);
+  });
+
+  test('keeps previous active element when triggering', () => {
+    const paragraph = document.createElement('p');
+    paragraph.classList.add('johannes-content-element');
+    paragraph.setAttribute('contenteditable', 'true');
+    document.body.appendChild(paragraph);
+    paragraph.focus();
+
+    let active: Element | null = null;
+    service.execCommand = jest.fn(() => { active = document.activeElement; });
+
+    button.htmlElement.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+    expect(active).toBe(paragraph);
+  });
 });
-
-// describe("AddBlockButton", () => {
-
-//     beforeEach(() => {
-//         document.body.innerHTML = `
-//         <div id="johannesEditor"></div>
-//     `;
-
-//         const editor = UIBuilder.build().start();
-//         expect(editor).toBeInstanceOf(Editor);
-//     });
-
-//     test("Add functionality", () => {
-
-//         let paragraphs = document.querySelectorAll("#johannesEditor .content p");
-//         expect(paragraphs.length).toBe(1);
-
-//         const addBlockButton = document.querySelector(".add-block") as HTMLButtonElement;
-
-//         addBlockButton.click();
-
-//         paragraphs = document.querySelectorAll("#johannesEditor .content p");
-//         expect(paragraphs.length).toBe(2);
-//     });
-// });
-
-
-
-
-
-
-
-
-
-
-
-
-// // import { UIBuilder } from "../../builders/UIBuilder";
-// // import { Editor } from "../editor/Editor";
-
-// // describe("AddBlockButton", () => {
-
-// //     beforeEach(() => {
-// //         // Setup the editor in the document body
-// //         document.body.innerHTML = `
-// //         <div id="johannesEditor"></div>
-// //         <script>
-// //             const editorConfig = {
-// //                 enableFloatingToolbar: true,
-// //                 enableQuickMenu: true,
-// //                 enableAddBlock: true,
-// //                 includeHeader: true,
-// //                 includeFirstParagraph: true,
-// //                 enableTitle: true,
-// //                 title: undefined
-// //             };
-// //             window.editorConfig = editorConfig;
-// //         </script>
-// //     `;
-
-// //         const editorConfig = {
-// //             enableFloatingToolbar: true,
-// //             enableQuickMenu: true,
-// //             enableAddBlock: true,
-// //             includeHeader: true,
-// //             includeFirstParagraph: true,
-// //             enableTitle: true,
-// //             title: undefined
-// //         };
-// //         window.editorConfig = editorConfig;
-
-// //         const editor = UIBuilder.build().start();
-// //         expect(editor).toBeInstanceOf(Editor);
-// //     });
-
-// //     test("Add functionality", () => {
-
-// //         let paragraphs = document.querySelectorAll("#johannesEditor .content p");
-// //         expect(paragraphs.length).toBe(1);
-
-// //         const addBlockButton = document.querySelector(".add-block") as HTMLButtonElement;
-
-// //         addBlockButton.click();
-
-// //         paragraphs = document.querySelectorAll("#johannesEditor .content p");
-// //         expect(paragraphs.length).toBe(2);
-// //     });
-// // });

--- a/src/components/add-block/AddBlockButton.ts
+++ b/src/components/add-block/AddBlockButton.ts
@@ -34,10 +34,21 @@ export class AddBlockButton extends BaseUIComponent {
 
     attachEvents(): void {
 
-        this.htmlElement.addEventListener("click", () => {
-
+        // Use pointerdown to capture the active element before the button gains
+        // focus. This allows inserting the new block relative to the currently
+        // focused block rather than always appending at the end of the content.
+        this.htmlElement.addEventListener("pointerdown", (event) => {
+            event.preventDefault();
             //TODO: Use command dispatcher
             this.blockOperationsService.execCommand(Commands.createDefaultBlock, false);
+        });
+
+        // Fallback for keyboard interaction
+        this.htmlElement.addEventListener("keydown", (event: KeyboardEvent) => {
+            if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                this.blockOperationsService.execCommand(Commands.createDefaultBlock, false);
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- ensure the add block button uses `pointerdown` to capture the current block before focus changes
- support keyboard activation and prevent unwanted focus
- add unit tests covering the button behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68476d28aa788332aaa90d8922281045