### PR TITLE
Fix paste reuses empty paragraph

### DIFF
--- a/src/components/editor/Editor.test.ts
+++ b/src/components/editor/Editor.test.ts
@@ -183,13 +183,18 @@ describe('Editor.handlePasteEvent', () => {
     test('uses next empty paragraph when pasting into title', () => {
         const html = '<p>First</p><p>Second</p><p>Third</p>';
 
+        const wrapper = document.createElement('div');
+        wrapper.classList.add('content-wrapper');
+
         const h1 = document.createElement('h1');
         h1.setAttribute('contenteditable', 'true');
         const title = document.createElement('div');
         title.classList.add('title');
         title.appendChild(h1);
-        document.body.appendChild(title);
+        wrapper.appendChild(title);
 
+        const content = document.createElement('div');
+        content.classList.add('content');
         const p = document.createElement('p');
         p.setAttribute('contenteditable', 'true');
         p.classList.add('johannes-content-element');
@@ -197,7 +202,10 @@ describe('Editor.handlePasteEvent', () => {
         const block = document.createElement('div');
         block.classList.add('block');
         block.appendChild(p);
-        document.body.appendChild(block);
+        content.appendChild(block);
+        wrapper.appendChild(content);
+
+        document.body.appendChild(wrapper);
 
         clipboardEvent = createPasteEvent(html, '', h1) as unknown as ClipboardEvent;
 

--- a/src/components/editor/Editor.ts
+++ b/src/components/editor/Editor.ts
@@ -291,17 +291,49 @@ export class Editor extends BaseUIComponent {
                         Editor.insertTextAtCursor(blocks[0].text);
                     }
     
-                    blocks.slice(1).forEach(block => {
-                        if (block.type === "ul" || block.type === "ol") {
-                            const first = block.items?.[0]?.text;
-                            const newBlock = blockOperationsService.insertBlock("block-" + block.type, first || "", null);
-    
-                            block.items?.slice(1).forEach(item => {
-                                blockOperationsService.insertLiIntoListBlock(item.text || "", newBlock);
-                            });
-    
+                    let nextEmptyBlock: HTMLElement | null = null;
+                    if (target?.tagName.toLowerCase() === 'h1') {
+                        const title = target.closest('.title');
+                        const maybeNext = title?.nextElementSibling as HTMLElement | null;
+                        if (maybeNext && maybeNext.classList.contains('block')) {
+                            const contentEl = maybeNext.querySelector('.johannes-content-element') as HTMLElement | null;
+                            if (contentEl && (contentEl.textContent || '').trim() === '') {
+                                nextEmptyBlock = maybeNext;
+                            }
+                        }
+                    }
+
+                    blocks.slice(1).forEach((block, index) => {
+                        if (index === 0 && nextEmptyBlock) {
+                            const contentEl = nextEmptyBlock.querySelector('.johannes-content-element') as HTMLElement | null;
+                            if (!contentEl) return;
+
+                            if (block.type === 'ul' || block.type === 'ol') {
+                                contentEl.textContent = block.items?.[0]?.text || '';
+                                DOMUtils.updatePlaceholderVisibility(contentEl);
+                                blockOperationsService.transformBlock(block.type, nextEmptyBlock);
+                                block.items?.slice(1).forEach(item => {
+                                    blockOperationsService.insertLiIntoListBlock(item.text || '', nextEmptyBlock);
+                                });
+                            } else {
+                                contentEl.textContent = block.text || '';
+                                DOMUtils.updatePlaceholderVisibility(contentEl);
+                                if (block.type !== 'p') {
+                                    blockOperationsService.transformBlock(block.type, nextEmptyBlock);
+                                }
+                            }
                         } else {
-                            blockOperationsService.insertBlock("block-" + block.type, block.text || "", null);
+                            if (block.type === "ul" || block.type === "ol") {
+                                const first = block.items?.[0]?.text;
+                                const newBlock = blockOperationsService.insertBlock("block-" + block.type, first || "", null);
+
+                                block.items?.slice(1).forEach(item => {
+                                    blockOperationsService.insertLiIntoListBlock(item.text || "", newBlock);
+                                });
+
+                            } else {
+                                blockOperationsService.insertBlock("block-" + block.type, block.text || "", null);
+                            }
                         }
                     });
                 }

--- a/src/components/editor/Editor.ts
+++ b/src/components/editor/Editor.ts
@@ -293,9 +293,10 @@ export class Editor extends BaseUIComponent {
     
                     let nextEmptyBlock: HTMLElement | null = null;
                     if (target?.tagName.toLowerCase() === 'h1') {
-                        const title = target.closest('.title');
-                        const maybeNext = title?.nextElementSibling as HTMLElement | null;
-                        if (maybeNext && maybeNext.classList.contains('block')) {
+                        const wrapper = target.closest('.content-wrapper');
+                        const content = wrapper?.querySelector('.content');
+                        const maybeNext = content?.querySelector('.block') as HTMLElement | null;
+                        if (maybeNext) {
                             const contentEl = maybeNext.querySelector('.johannes-content-element') as HTMLElement | null;
                             if (contentEl && (contentEl.textContent || '').trim() === '') {
                                 nextEmptyBlock = maybeNext;


### PR DESCRIPTION
## Summary
- reuse first empty paragraph block when pasting multiple blocks into the title
- test paste reuse behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68476e3c5ab483328af71fefa6abf350