### PR TITLE
Fix add block when all paragraphs empty

### DIFF
--- a/src/components/add-block/AddBlockButton.test.ts
+++ b/src/components/add-block/AddBlockButton.test.ts
@@ -1,97 +1,43 @@
-import { UIBuilder } from "../../builders/UIBuilder";
 import { Editor } from "../editor/Editor";
-
+import { EditorBuilder } from "@/builders/EditorBuilder";
+import { DependencyContainer } from "@/core/DependencyContainer";
+import { registerEditorDependenciesForTests } from "../../../tests/helpers/registerEditorDependencies";
+import { ElementFactoryService } from "@/services/element-factory/ElementFactoryService";
+import { BlockOperationsService } from "@/services/block-operations/BlockOperationsService";
+import { FocusStack } from "@/core/FocusStack";
+import { Memento } from "@/core/Memento";
 
 describe("AddBlockButton", () => {
-    test("dummy", () => {
-        expect(true).toBe(true);
+    beforeEach(() => {
+        document.body.innerHTML = '<div id="johannesEditor"></div>';
+        (window as any).editorConfig = { enableAddBlock: true };
+
+        registerEditorDependenciesForTests();
+        DependencyContainer.Instance.register('IElementFactoryService', () => ElementFactoryService.getInstance());
+        DependencyContainer.Instance.register('IFocusStack', () => FocusStack.getInstance());
+        DependencyContainer.Instance.register('IMemento', () => Memento.getInstance());
+        DependencyContainer.Instance.register('IBlockOperationsService', () => BlockOperationsService.getInstance());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        document.body.innerHTML = '';
+    });
+
+    test("adds a new paragraph when the only existing block is empty", (done) => {
+        const editor = EditorBuilder.build();
+        expect(editor).toBeInstanceOf(Editor);
+
+        const content = document.querySelector('#johannesEditor .content') as HTMLElement;
+        const addBlockButton = document.querySelector('.add-block') as HTMLButtonElement;
+
+        expect(content.querySelectorAll('.block').length).toBe(1);
+
+        addBlockButton.click();
+
+        setTimeout(() => {
+            expect(content.querySelectorAll('.block').length).toBe(2);
+            done();
+        }, 0);
     });
 });
-
-// describe("AddBlockButton", () => {
-
-//     beforeEach(() => {
-//         document.body.innerHTML = `
-//         <div id="johannesEditor"></div>
-//     `;
-
-//         const editor = UIBuilder.build().start();
-//         expect(editor).toBeInstanceOf(Editor);
-//     });
-
-//     test("Add functionality", () => {
-
-//         let paragraphs = document.querySelectorAll("#johannesEditor .content p");
-//         expect(paragraphs.length).toBe(1);
-
-//         const addBlockButton = document.querySelector(".add-block") as HTMLButtonElement;
-
-//         addBlockButton.click();
-
-//         paragraphs = document.querySelectorAll("#johannesEditor .content p");
-//         expect(paragraphs.length).toBe(2);
-//     });
-// });
-
-
-
-
-
-
-
-
-
-
-
-
-// // import { UIBuilder } from "../../builders/UIBuilder";
-// // import { Editor } from "../editor/Editor";
-
-// // describe("AddBlockButton", () => {
-
-// //     beforeEach(() => {
-// //         // Setup the editor in the document body
-// //         document.body.innerHTML = `
-// //         <div id="johannesEditor"></div>
-// //         <script>
-// //             const editorConfig = {
-// //                 enableFloatingToolbar: true,
-// //                 enableQuickMenu: true,
-// //                 enableAddBlock: true,
-// //                 includeHeader: true,
-// //                 includeFirstParagraph: true,
-// //                 enableTitle: true,
-// //                 title: undefined
-// //             };
-// //             window.editorConfig = editorConfig;
-// //         </script>
-// //     `;
-
-// //         const editorConfig = {
-// //             enableFloatingToolbar: true,
-// //             enableQuickMenu: true,
-// //             enableAddBlock: true,
-// //             includeHeader: true,
-// //             includeFirstParagraph: true,
-// //             enableTitle: true,
-// //             title: undefined
-// //         };
-// //         window.editorConfig = editorConfig;
-
-// //         const editor = UIBuilder.build().start();
-// //         expect(editor).toBeInstanceOf(Editor);
-// //     });
-
-// //     test("Add functionality", () => {
-
-// //         let paragraphs = document.querySelectorAll("#johannesEditor .content p");
-// //         expect(paragraphs.length).toBe(1);
-
-// //         const addBlockButton = document.querySelector(".add-block") as HTMLButtonElement;
-
-// //         addBlockButton.click();
-
-// //         paragraphs = document.querySelectorAll("#johannesEditor .content p");
-// //         expect(paragraphs.length).toBe(2);
-// //     });
-// // });

--- a/src/components/editor/Editor.ts
+++ b/src/components/editor/Editor.ts
@@ -246,14 +246,6 @@ export class Editor extends BaseUIComponent {
             }
         });
 
-        // Remove duplicate empty blocks leaving only one
-        const blocks = content.querySelectorAll('.block');
-        if (blocks.length > 1) {
-            const empties = Array.from(blocks).filter(b => (b.textContent || '').trim() === '');
-            if (empties.length === blocks.length) {
-                empties.slice(1).forEach(b => b.remove());
-            }
-        }
     }
 
     static handlePasteEvent(event: ClipboardEvent, blockOperationsService: IBlockOperationsService) {


### PR DESCRIPTION
## Summary
- remove cleanup that deleted extra empty paragraphs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684771c2c9fc8332a1255b3c29761992