### PR TITLE
Fix table listener conflict with list enter

### DIFF
--- a/src/components/floating-toolbar/table-context/Toolbar.ts
+++ b/src/components/floating-toolbar/table-context/Toolbar.ts
@@ -136,21 +136,20 @@ export class Toolbar extends FloatingToolbarBase implements ITableContextFloatin
         const target = event.target as HTMLElement;
         const currentCell = target.closest(DOMElements.TD) as HTMLTableCellElement;
 
-        if (currentCell && !currentCell.matches('.gist td')) {
+        if (!currentCell || currentCell.matches('.gist td')) {
+            return;
+        }
 
-            if (event.key == KeyboardKeys.Enter && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
-                event.stopImmediatePropagation();
-                // alert("jump to next line");
-            } else if (event.key == KeyboardKeys.Escape && this.canHide && !TextContextFloatingToolbar.getInstance().isVisible) {
-
-                setTimeout(() => {
-                    if (this.canHide) {
-                        event.stopImmediatePropagation();
-                        this.clearAll();
-                        this.hide();
-                    }
-                }, 10);
-            }
+        if (event.key == KeyboardKeys.Enter && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+            event.stopImmediatePropagation();
+        } else if (event.key == KeyboardKeys.Escape && this.canHide && !TextContextFloatingToolbar.getInstance().isVisible) {
+            setTimeout(() => {
+                if (this.canHide) {
+                    event.stopImmediatePropagation();
+                    this.clearAll();
+                    this.hide();
+                }
+            }, 10);
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent table keydown handler from affecting non-table content
- add regression test covering enter on last list item
- simplify paragraph splitting test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684779cd1c88833282ee746edd7d6aa2