### PR TITLE
Fix list events when nested in tables

### DIFF
--- a/src/components/content/Content.test.ts
+++ b/src/components/content/Content.test.ts
@@ -1,5 +1,8 @@
 import { Content } from "./Content";
 import { DependencyContainer } from "@/core/DependencyContainer";
+import { TableUtils } from "@/utilities/TableUtils";
+import { CustomEvents } from "@/common/CustomEvents";
+import { Commands } from "@/commands/Commands";
 
 class MockShortcutListeners {
   bind = jest.fn();
@@ -24,6 +27,9 @@ class MockTableContextFloatingToolbar {
   show = jest.fn();
   hide = jest.fn();
   update = jest.fn();
+  get isVisible() {
+    return false;
+  }
 }
 
 describe("Content", () => {
@@ -37,5 +43,72 @@ describe("Content", () => {
   test("Create element", () => {
     const content = Content.getInstance();
     expect(content).toBeInstanceOf(Content);
+  });
+
+  test("pressing Enter in a table cell triggers table navigation", () => {
+    const controller = document.createElement("div");
+    controller.className = "table-controller";
+    const table = document.createElement("table");
+    const tbody = document.createElement("tbody");
+    const row1 = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.className = "editable";
+    cell.setAttribute("data-placeholder", "cell");
+    cell.contentEditable = "true";
+    row1.appendChild(cell);
+    tbody.appendChild(row1);
+    table.appendChild(tbody);
+    controller.appendChild(table);
+    document.body.appendChild(controller);
+
+    const spy = jest.spyOn(TableUtils, "moveFocusToBelowCell").mockReturnValue(true);
+
+    Content.getInstance();
+
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true });
+    cell.dispatchEvent(event);
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test("pressing Enter in list inside table cell creates new list item", () => {
+    const controller = document.createElement("div");
+    controller.className = "table-controller";
+    const table = document.createElement("table");
+    const tbody = document.createElement("tbody");
+    const row1 = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.className = "editable";
+    cell.setAttribute("data-placeholder", "cell");
+    cell.contentEditable = "true";
+    const ul = document.createElement("ul");
+    ul.className = "johannes-content-element swittable list";
+    const li = document.createElement("li");
+    li.className = "list-item";
+    const div = document.createElement("div");
+    div.className = "focusable editable";
+    div.contentEditable = "true";
+    li.appendChild(div);
+    ul.appendChild(li);
+    cell.appendChild(ul);
+    row1.appendChild(cell);
+    tbody.appendChild(row1);
+    table.appendChild(tbody);
+    controller.appendChild(table);
+    document.body.appendChild(controller);
+
+    const spy = jest.spyOn(TableUtils, "moveFocusToBelowCell");
+    const emitted = jest.fn();
+    document.addEventListener(CustomEvents.emittedCommand, emitted);
+
+    Content.getInstance();
+
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true });
+    div.dispatchEvent(event);
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(emitted).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { command: Commands.insertNew } })
+    );
   });
 });

--- a/src/components/content/Content.test.ts
+++ b/src/components/content/Content.test.ts
@@ -27,8 +27,9 @@ class MockTableContextFloatingToolbar {
   show = jest.fn();
   hide = jest.fn();
   update = jest.fn();
+  visible = false;
   get isVisible() {
-    return false;
+    return this.visible;
   }
 }
 
@@ -100,6 +101,51 @@ describe("Content", () => {
     const spy = jest.spyOn(TableUtils, "moveFocusToBelowCell");
     const emitted = jest.fn();
     document.addEventListener(CustomEvents.emittedCommand, emitted);
+
+    Content.getInstance();
+
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true });
+    div.dispatchEvent(event);
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(emitted).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { command: Commands.insertNew } })
+    );
+  });
+
+  test("pressing Enter in list inside table cell when toolbar visible creates new list item", () => {
+    const controller = document.createElement("div");
+    controller.className = "table-controller";
+    const table = document.createElement("table");
+    const tbody = document.createElement("tbody");
+    const row1 = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.className = "editable";
+    cell.setAttribute("data-placeholder", "cell");
+    cell.contentEditable = "true";
+    const ul = document.createElement("ul");
+    ul.className = "johannes-content-element swittable list";
+    const li = document.createElement("li");
+    li.className = "list-item";
+    const div = document.createElement("div");
+    div.className = "focusable editable";
+    div.contentEditable = "true";
+    li.appendChild(div);
+    ul.appendChild(li);
+    cell.appendChild(ul);
+    row1.appendChild(cell);
+    tbody.appendChild(row1);
+    table.appendChild(tbody);
+    controller.appendChild(table);
+    document.body.appendChild(controller);
+
+    const spy = jest.spyOn(TableUtils, "moveFocusToBelowCell");
+    const emitted = jest.fn();
+    document.addEventListener(CustomEvents.emittedCommand, emitted);
+
+    const toolbar = new MockTableContextFloatingToolbar();
+    toolbar.visible = true;
+    DependencyContainer.Instance.register("ITableContextFloatingToolbar", () => toolbar);
 
     Content.getInstance();
 

--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -251,7 +251,8 @@ export class Content extends BaseUIComponent {
                 event.preventDefault();
 
                 const tableController = (event.target as Element).closest(".table-controller");
-                if (tableController) {
+                const insideList = (event.target as Element).closest(".list");
+                if (tableController && !insideList) {
                     const activeCell = (event.target as Element).closest("td, th") as HTMLTableCellElement;
                     const table = tableController.querySelector("table") as HTMLTableElement;
                     if (activeCell) {

--- a/src/components/content/Content.ts
+++ b/src/components/content/Content.ts
@@ -246,25 +246,28 @@ export class Content extends BaseUIComponent {
                 return;
             }
 
-            if (event.key === KeyboardKeys.Enter && !event.shiftKey && !this.quickMenu.isVisible && !this.tableToolbar.isVisible) {
-
-                event.preventDefault();
+            if (event.key === KeyboardKeys.Enter && !event.shiftKey && !this.quickMenu.isVisible) {
 
                 const tableController = (event.target as Element).closest(".table-controller");
                 const insideList = (event.target as Element).closest(".list");
+
+                event.preventDefault();
+
                 if (tableController && !insideList) {
-                    const activeCell = (event.target as Element).closest("td, th") as HTMLTableCellElement;
-                    const table = tableController.querySelector("table") as HTMLTableElement;
-                    if (activeCell) {
+                    if (!this.tableToolbar.isVisible) {
+                        const activeCell = (event.target as Element).closest("td, th") as HTMLTableCellElement;
+                        const table = tableController.querySelector("table") as HTMLTableElement;
+                        if (activeCell) {
 
-                        const focusedBelow = TableUtils.moveFocusToBelowCell(table, activeCell);
-                        if (!focusedBelow) {
+                            const focusedBelow = TableUtils.moveFocusToBelowCell(table, activeCell);
+                            if (!focusedBelow) {
 
-                            document.dispatchEvent(new CustomEvent<ICommandEventDetail>(CustomEvents.emittedCommand, {
-                                detail: {
-                                    command: Commands.focusOnNextBlock,
-                                }
-                            }));
+                                document.dispatchEvent(new CustomEvent<ICommandEventDetail>(CustomEvents.emittedCommand, {
+                                    detail: {
+                                        command: Commands.focusOnNextBlock,
+                                    }
+                                }));
+                            }
                         }
                     }
 
@@ -276,7 +279,6 @@ export class Content extends BaseUIComponent {
                 }
 
                 // Create a default block when press Enter
-                event.preventDefault();
                 event.stopImmediatePropagation();
 
                 document.dispatchEvent(new CustomEvent<ICommandEventDetail>(CustomEvents.emittedCommand, {


### PR DESCRIPTION
## Summary
- avoid table handlers when Enter is pressed inside lists
- test list behavior inside table cells

## Testing
- `npm test --silent`
- `npm test --silent src/components/content/Content.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68477e2fb8088332ab38991efb4f775b