### PR TITLE
Add inline formula support

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1492,6 +1492,11 @@ pre code {
     min-height: 1.2em;
 }
 
+.inline-math {
+    display: inline-block;
+    min-height: 1.2em;
+}
+
 
 
 

--- a/src/commands/CommandDispatcher.ts
+++ b/src/commands/CommandDispatcher.ts
@@ -116,6 +116,10 @@ export class CommandDispatcher {
                 this.textOperationsService.execInlineCode();
                 break;
 
+            case Commands.insertInlineFormula:
+                this.textOperationsService.execInlineFormula();
+                break;
+
             case Commands.toggleItalic:
                 this.textOperationsService.execItalic();
                 break;

--- a/src/commands/Commands.ts
+++ b/src/commands/Commands.ts
@@ -6,6 +6,7 @@ export enum Commands {
     changeCalloutBackgroundColor = "changeCalloutBackgroundColor",
     toggleForeColor = "foreColor",
     toggleInlineCode = "inlineCode",
+    insertInlineFormula = "inlineFormula",
     toggleLink = "createLink",
     linkReadyToInsert = "linkReadyToInsert",
     toggleUnderline = "underline",

--- a/src/components/floating-toolbar/text-context/Builder.ts
+++ b/src/components/floating-toolbar/text-context/Builder.ts
@@ -106,6 +106,10 @@ export class Builder {
         const inlineCode = ButtonGroupItem.create(Commands.toggleInlineCode, "Code", SVGIcon.create(Icons.InlineCode, Sizes.large));
         inlineCode.setId(ButtonIDs.InlineCode);
         inlineCode.appendTo(groupButton);
+
+        const inlineFormula = ButtonGroupItem.create(Commands.insertInlineFormula, "Formula", SVGIcon.create(Icons.Formula, Sizes.large));
+        inlineFormula.setId(ButtonIDs.InlineFormula);
+        inlineFormula.appendTo(groupButton);
         
         const strikethrough = ButtonGroupItem.create(Commands.toggleStrikeThrough, "Strike-through", SVGIcon.create(Icons.StrikeThrough, Sizes.large));
         strikethrough.setId(ButtonIDs.Strikethrough);

--- a/src/components/floating-toolbar/text-context/Toolbar.ts
+++ b/src/components/floating-toolbar/text-context/Toolbar.ts
@@ -33,6 +33,7 @@ export class Toolbar extends FloatingToolbarBase {
     private turnIntoOptions: HTMLElement | null = null;
     private turnIntoSeparator: HTMLElement | null = null;
     private inlineCodeButton: HTMLElement | null = null;
+    private inlineFormulaButton: HTMLElement | null = null;
     private linkButton: HTMLElement | null = null;
     private textOperationsSeparator: HTMLElement | null = null;
 
@@ -148,6 +149,10 @@ export class Toolbar extends FloatingToolbarBase {
             this.inlineCodeButton = document.querySelector("#inlineCodeButton");
         }
 
+        if (!this.inlineFormulaButton) {
+            this.inlineFormulaButton = document.querySelector("#inlineFormulaButton");
+        }
+
         if (!this.linkButton) {
             this.linkButton = document.querySelector("#linkButton");
         }        
@@ -167,6 +172,7 @@ export class Toolbar extends FloatingToolbarBase {
             this.turnIntoOptions!.style.display = "none";
             this.turnIntoSeparator!.style.display = "none";
             this.inlineCodeButton!.style.display = "none";
+            this.inlineFormulaButton!.style.display = "none";
             this.textOperationsSeparator!.style.display = "none";
 
         } else {
@@ -175,6 +181,7 @@ export class Toolbar extends FloatingToolbarBase {
             this.turnIntoOptions!.style.display = "flex";
             this.turnIntoSeparator!.style.display = "flex";
             this.inlineCodeButton!.style.display = "flex";
+            this.inlineFormulaButton!.style.display = "flex";
             this.textOperationsSeparator!.style.display = "flex";
         }
     }

--- a/src/core/ButtonIDs.ts
+++ b/src/core/ButtonIDs.ts
@@ -4,6 +4,7 @@ export enum ButtonIDs {
     Italic = "italicButton",
     Underline = "underlineButton",
     InlineCode = "inlineCodeButton",
+    InlineFormula = "inlineFormulaButton",
     Strikethrough = "strikethroughButton",
     AlignLeft = "alignLeft",
     AlignCenter = "alignCenter",

--- a/src/services/text-operations/ITextOperationsService.ts
+++ b/src/services/text-operations/ITextOperationsService.ts
@@ -10,6 +10,7 @@ export interface ITextOperationsService {
     execItalic(): void;
     execStrikeThrough(): void;
     execInlineCode(): void;
+    execInlineFormula(): void;
     execUnderline(): void
     execHiliteColor(value: string): void;
     execForeColor(value: string): void;

--- a/src/services/text-operations/TextOperationsService.ts
+++ b/src/services/text-operations/TextOperationsService.ts
@@ -381,6 +381,14 @@ export class TextOperationsService implements ITextOperationsService {
         renderPreview();
 
         range.insertNode(container);
+
+        const parent = container.closest('[contenteditable="true"]');
+        if (parent) {
+            DOMUtils.trimEmptyTextAndBrElements(parent);
+            (parent as HTMLElement).normalize();
+            DOMUtils.mergeInlineElements(parent as HTMLElement);
+        }
+
         range.setStartAfter(container);
         range.collapse(true);
         selection.removeAllRanges();
@@ -389,7 +397,7 @@ export class TextOperationsService implements ITextOperationsService {
         const inputter = MathInputter.getInstance();
         inputter.setTarget(container, renderPreview);
         inputter.focusStack.push(container);
-        inputter.show();
+        setTimeout(() => inputter.show(), 0);
 
         EventEmitter.emitDocChangedEvent();
     }


### PR DESCRIPTION
## Summary
- add `insertInlineFormula` command
- handle inline formula insertion in text toolbar
- expose inline formula button id
- support inline formula button in toolbar logic
- style `.inline-math` elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68477ea0819c8332a39be60a1d4a62b1