### PR TITLE
Improve inline formula behavior

### DIFF
--- a/src/components/math-inputter/MathInputter.ts
+++ b/src/components/math-inputter/MathInputter.ts
@@ -55,9 +55,7 @@ export class MathInputter extends BaseUIComponent {
         const input = document.createElement("div");
         input.classList.add("math-input", "focusable", "editable");
         input.contentEditable = "true";
-        input.setAttribute("data-placeholder", "\\text{Formula}");
-        input.innerHTML = "<br>";
-        DOMUtils.updatePlaceholderVisibility(input);
+        input.innerHTML = "";
 
         const button = document.createElement("button");
         button.classList.add("blue-button");
@@ -89,6 +87,7 @@ export class MathInputter extends BaseUIComponent {
         this.ensureInputElements();
         document.addEventListener(DefaultJSEvents.Keydown, this.handleKeydown.bind(this), true);
         document.addEventListener(DefaultJSEvents.Click, this.handleClick.bind(this));
+        document.addEventListener(DefaultJSEvents.SelectionChange, this.handleSelectionChange.bind(this));
 
         this.input?.addEventListener("input", () => this.updateFormula());
         this.done?.addEventListener(DefaultJSEvents.Click, (e) => {
@@ -98,6 +97,28 @@ export class MathInputter extends BaseUIComponent {
         });
 
         super.attachUIEvent();
+    }
+
+    private handleSelectionChange() {
+        const sel = window.getSelection();
+        if (!sel || sel.rangeCount === 0 || !sel.isCollapsed) return;
+
+        let node: Node | null = sel.anchorNode;
+        if (!node) return;
+
+        if (node.nodeType === Node.TEXT_NODE) {
+            node = node.parentElement;
+        }
+
+        const container = (node as HTMLElement).closest('.inline-math');
+        if (container) {
+            const render = (container as any).renderPreview || (() => {});
+            if (this.currentTarget !== container || !this.isVisible) {
+                this.focusStack.push(container as HTMLElement);
+                this.setTarget(container as HTMLElement, render);
+                this.show();
+            }
+        }
     }
 
     private handleKeydown(event: KeyboardEvent) {

--- a/src/services/text-operations/TextOperationsService.ts
+++ b/src/services/text-operations/TextOperationsService.ts
@@ -358,10 +358,17 @@ export class TextOperationsService implements ITextOperationsService {
         }
 
         const range = selection.getRangeAt(0);
+
+        let selectedText = '';
+        if (!selection.isCollapsed) {
+            selectedText = range.toString();
+            range.deleteContents();
+        }
+
         const container = document.createElement('span');
         container.classList.add('inline-math', CommonClasses.ShowMathInputOnClick, CommonClasses.ContentElement);
         container.setAttribute('data-content-type', ContentTypes.Math);
-        container.dataset.formula = '';
+        container.dataset.formula = selectedText;
 
         const renderPreview = () => {
             const formula = container.dataset.formula || '';
@@ -380,7 +387,13 @@ export class TextOperationsService implements ITextOperationsService {
         (container as any).renderPreview = renderPreview;
         renderPreview();
 
+        const startMarker = document.createTextNode('\u200B');
+        range.insertNode(startMarker);
+        range.setStartAfter(startMarker);
         range.insertNode(container);
+        range.setStartAfter(container);
+        const endMarker = document.createTextNode('\u200B');
+        range.insertNode(endMarker);
 
         const parent = container.closest('[contenteditable="true"]');
         if (parent) {
@@ -389,7 +402,7 @@ export class TextOperationsService implements ITextOperationsService {
             DOMUtils.mergeInlineElements(parent as HTMLElement);
         }
 
-        range.setStartAfter(container);
+        range.setStartAfter(endMarker);
         range.collapse(true);
         selection.removeAllRanges();
         selection.addRange(range);

--- a/src/utilities/DOMUtils.ts
+++ b/src/utilities/DOMUtils.ts
@@ -923,11 +923,20 @@ export class DOMUtils {
             if (children[i].nodeType === Node.ELEMENT_NODE) {
                 const childElement = children[i] as HTMLElement;
                 if (['SPAN', 'CODE', 'EM', 'STRONG', 'B', 'I'].includes(childElement.nodeName)) {
-                    while (i < children.length - 1 && childElement.nextSibling && childElement.nextSibling.nodeType === Node.ELEMENT_NODE && childElement.nodeName === (childElement.nextSibling as HTMLElement).nodeName) {
-                        while ((childElement.nextSibling as HTMLElement).childNodes.length > 0) {
-                            childElement.appendChild((childElement.nextSibling as HTMLElement).firstChild!);
+                    while (
+                        i < children.length - 1 &&
+                        childElement.nextSibling &&
+                        childElement.nextSibling.nodeType === Node.ELEMENT_NODE &&
+                        childElement.nodeName === (childElement.nextSibling as HTMLElement).nodeName
+                    ) {
+                        const nextElement = childElement.nextSibling as HTMLElement;
+                        if (childElement.classList.contains('inline-math') || nextElement.classList.contains('inline-math')) {
+                            break;
                         }
-                        element.removeChild(childElement.nextSibling);
+                        while (nextElement.childNodes.length > 0) {
+                            childElement.appendChild(nextElement.firstChild!);
+                        }
+                        element.removeChild(nextElement);
                     }
                     DOMUtils.mergeInlineElements(childElement);
                 }


### PR DESCRIPTION
## Summary
- remove placeholder markup from math inputter
- open formula input when caret enters an existing formula
- prevent different inline formulas from merging
- allow converting selected text into an inline formula with markers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848b2c59e248332ba02f86495887533